### PR TITLE
Make sure when skipping card info that coupon duration is not "once"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog][keep a changelog] and this project adh
 - Implemented 3D secure for payment cards requiring authentication.
 - Add missing locale to pelcro's native buttons [PRIVATE]
 
+### Fixed
+
+- Only skip card if 100% coupon code is set to forever
+
 ## [Released]
 
 ## [0.12.1] - 2021-04-26

--- a/src/Components/PaymentMethod/PaymentMethodContainer.js
+++ b/src/Components/PaymentMethod/PaymentMethodContainer.js
@@ -48,6 +48,7 @@ import {
  * @property {boolean} disableSubmit
  * @property {boolean} isLoading
  * @property {boolean} disableCouponButton
+ * @property {object} couponObject
  * @property {string} couponCode
  * @property {string} couponError
  * @property {boolean} enableCouponField
@@ -65,6 +66,7 @@ const initialState = {
   disableSubmit: false,
   isLoading: false,
   disableCouponButton: false,
+  couponObject: null,
   couponCode: "",
   couponError: "",
   enableCouponField: false,
@@ -181,7 +183,7 @@ const PaymentMethodContainerWithoutStripe = ({
 
   const onApplyCouponCode = (state, dispatch) => {
     dispatch({ type: DISABLE_COUPON_BUTTON, payload: true });
-    const { couponCode, canMakePayment } = state;
+    const { couponCode } = state;
 
     if (couponCode) {
       window.Pelcro.order.create(
@@ -208,6 +210,12 @@ const PaymentMethodContainerWithoutStripe = ({
             type: SHOW_ALERT,
             payload: { type: "error", content: "" }
           });
+
+          dispatch({
+            type: SET_COUPON,
+            payload: res.data.coupon
+          });
+
           dispatch({
             type: SET_PERCENT_OFF,
             payload: `${res.data.coupon?.percent_off}%`
@@ -570,7 +578,10 @@ const PaymentMethodContainerWithoutStripe = ({
     ) {
       const { updatedPrice } = state;
       // When price is 0, we allow submitting without card info
-      if (updatedPrice === 0) {
+      if (
+        updatedPrice === 0 &&
+        state.coupon?.duration === "forever"
+      ) {
         return subscribe({}, state, dispatch);
       }
     }


### PR DESCRIPTION
## Description [[STORY LINK]](https://app.asana.com/0/1167682760753289/1200247967218861/f)

When we skip card info for free payments, we need to make sure coupon duration on the platform is not set to "once" as that will fail to charge on subsequent renewals.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist
<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->
- [x] Added a changelog entry.
- [x] Tested changes locally.


## Screenshots <!-- If available -->
![chrome-capture (11)](https://user-images.githubusercontent.com/6924756/116421338-0712a300-a83f-11eb-890a-a1c7889353e2.gif)

