### PR TITLE
[FIX] Triggering coupon flow with empty spaces

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog][keep a changelog] and this project adh
 
 ## [Unreleased]
 
+### Fixed
+
+- Triggering coupon flow with empty spaces.
+
 ## [Released]
 
 ## [0.14.0] - 2021-04-28

--- a/src/Components/PaymentMethod/PaymentMethodContainer.js
+++ b/src/Components/PaymentMethod/PaymentMethodContainer.js
@@ -182,10 +182,11 @@ const PaymentMethodContainerWithoutStripe = ({
   };
 
   const onApplyCouponCode = (state, dispatch) => {
-    dispatch({ type: DISABLE_COUPON_BUTTON, payload: true });
     const { couponCode } = state;
 
-    if (couponCode) {
+    if (couponCode?.trim()) {
+      dispatch({ type: DISABLE_COUPON_BUTTON, payload: true });
+
       window.Pelcro.order.create(
         {
           auth_token: window.Pelcro.user.read().auth_token,


### PR DESCRIPTION
## Description [[STORY LINK]](<!-- link here -->)

<!--- Describe your changes in detail here -->
The coupon field accepts empty spaces as an input which triggers a weird flow
Now we validate the input before sending a request for the coupon.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist
<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->
- [x] Added a changelog entry.
- [x] Tested changes locally.
- [ ] Updated documentation.


## Screenshots <!-- If available -->
![Adding spaces](https://user-images.githubusercontent.com/6924756/116894023-e2993b00-ac31-11eb-81b6-77190e7e05ca.png)