### PR TITLE
fix(usePelcro): gift recipient field not getting reset when resetState is called

### DIFF
--- a/src/hooks/usePelcro/index.js
+++ b/src/hooks/usePelcro/index.js
@@ -14,6 +14,7 @@ export const initialState = {
   plan: null,
   isGift: false,
   isRenewingGift: false,
+  giftRecipient: null,
   giftCode: "",
   subscriptionIdToRenew: null,
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -185,10 +185,15 @@ export const disableScroll = () => {
 export const trackSubscriptionOnGA = () => {
   const { product, plan, couponCode } = usePelcro.getStore();
 
-  const subscriptions = window.Pelcro.subscription.list();
-  const lastSubscription = subscriptions?.[subscriptions.length - 1];
+  /*   
+  getting the latest subscription id from invoices instead of subscriptions
+  to handle gifted subs which are not added to subs list
+  */
+  const invoices = window.Pelcro.user.read().invoices;
+  const lastSubscriptionId =
+    invoices?.[invoices.length - 1].subscription_id;
 
-  if (!lastSubscription) {
+  if (!lastSubscriptionId) {
     return;
   }
 
@@ -197,14 +202,14 @@ export const trackSubscriptionOnGA = () => {
   });
 
   ReactGA?.plugin?.execute?.("ecommerce", "addTransaction", {
-    id: lastSubscription.id,
+    id: lastSubscriptionId,
     affiliation: "Pelcro",
     revenue: plan?.amount ? plan.amount / 100 : 0,
     coupon: couponCode
   });
 
   ReactGA?.plugin?.execute?.("ecommerce", "addItem", {
-    id: lastSubscription.id,
+    id: lastSubscriptionId,
     name: product.name,
     category: product.description,
     variant: plan.nickname,


### PR DESCRIPTION
## Description

- fix [gift recipient field not getting reset when resetState is called](https://app.asana.com/0/1199393268587978/1200561514293003)
- fix [analytics not showing gifted subscriptions as e-commerce transactions](https://app.asana.com/0/1199393268587978/1200450203940475)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist
<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->
- [] Added a changelog entry.
- [x] Tested changes locally.
- [ ] Updated documentation.