### PR TITLE
fix(profile picture): success alert not showing up

### DIFF
--- a/src/Components/ProfilePicChange/ProfilePicChangeContainer.js
+++ b/src/Components/ProfilePicChange/ProfilePicChangeContainer.js
@@ -71,6 +71,13 @@ const ProfilePicChangeContainer = ({
             });
             return onChangeFailure(err);
           }
+          dispatch({
+            type: SHOW_ALERT,
+            payload: {
+              type: "success",
+              content: t("messages.pictureUpdated")
+            }
+          });
           return onChangeSuccess();
         }
       );

--- a/src/translations/en/userEdit.json
+++ b/src/translations/en/userEdit.json
@@ -17,6 +17,7 @@
   },
   "messages": {
     "userUpdated": "Thanks! Your profile was updated successfully.",
-    "pictureRemoved": "Your profile picture was removed successfully."
+    "pictureRemoved": "Your profile picture was removed successfully.",
+    "pictureUpdated": "Your profile picture was updated successfully."
   }
 }

--- a/src/translations/fr/userEdit.json
+++ b/src/translations/fr/userEdit.json
@@ -17,6 +17,7 @@
   },
   "messages": {
     "userUpdated": "Votre profil a été mis à jour avec succès.",
-    "pictureRemoved": "Votre photo de profil a été supprimée avec succès."
+    "pictureRemoved": "Votre photo de profil a été supprimée avec succès.",
+    "pictureUpdated": "Votre photo de profil a été mise à jour avec succès."
   }
 }


### PR DESCRIPTION
## Description [[STORY LINK]](https://app.asana.com/0/1199393268587978/1200557692717565)

- fix alert now showing up after successfully updating user's profile picture


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist
<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->
- [ ] Added a changelog entry.
- [x] Tested changes locally.
- [ ] Updated documentation.


## Screenshots <!-- If available -->

![msg](https://user-images.githubusercontent.com/18618809/124508417-2ba37200-ddd0-11eb-8852-0a5e09499382.png)

