### PR TITLE
feat: dispatch modal view event with each modal displayed

### DIFF
--- a/src/Components/PelcroModalController/PelcroModalController.service.js
+++ b/src/Components/PelcroModalController/PelcroModalController.service.js
@@ -97,6 +97,25 @@ export const initGATracking = () => {
   ReactGA?.plugin?.require?.("ecommerce");
 };
 
+export const dispatchModalDisplayEvents = (modalName) => {
+  ReactGA?.event?.({
+    category: "VIEWS",
+    action: `${modalName
+      ?.replace("pelcro-", "")
+      ?.replaceAll("-", " ")} viewed`,
+    nonInteraction: true
+  });
+
+  window.Pelcro.insight.track("Modal Displayed", {
+    name: `${modalName?.replace("pelcro-", "")?.replaceAll("-", " ")}`
+  });
+
+  const modalDisplayEvent = new CustomEvent("PelcroModalDisplay", {
+    detail: { modalName }
+  });
+  document.dispatchEvent(modalDisplayEvent);
+};
+
 const { whenSiteReady, whenEcommerceLoaded } = usePelcro.getStore();
 
 export const renderShopView = (shopComponent) => {

--- a/src/SubComponents/Modal.js
+++ b/src/SubComponents/Modal.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
-import ReactGA from "react-ga";
 import { ReactComponent as CloseIcon } from "../assets/x-icon.svg";
+import { dispatchModalDisplayEvents } from "../Components/PelcroModalController/PelcroModalController.service";
 import { usePelcro } from "../hooks/usePelcro";
 
 /**
@@ -17,17 +17,7 @@ export function Modal({
   const resetView = usePelcro((state) => state.resetView);
   useEffect(() => {
     onDisplay?.();
-    ReactGA?.event?.({
-      category: "VIEWS",
-      action: `${id
-        ?.replace("pelcro-", "")
-        ?.replaceAll("-", " ")} viewed`,
-      nonInteraction: true
-    });
-
-    window.Pelcro.insight.track("Modal Displayed", {
-      name: `${id?.replace("pelcro-", "")?.replaceAll("-", " ")}`
-    });
+    dispatchModalDisplayEvents(id);
   }, []);
 
   const onClose = () => {


### PR DESCRIPTION
## Description [[STORY LINK]](https://app.asana.com/0/1167682760753289/1200447293373911/f)

<!--- Describe your changes in detail here -->
When a modal is viewed, we should trigger a JS event called PelcroModalDisplay. I should expect to listen to it as such:
window.addEventListener('PelcroModalDisplay', (e) => e.detail.modalName)
where modalName is the name of the modal that we are using. For example, 'OrderConfirmModal' will trigger a view event with modalName='OrderConfirmModal'.

#### Usage
```js
document.addEventListener('PelcroModalDisplay', (e) => {
	console.log(e.detail.modalName)
});
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist
<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->
- [ ] Tested changes locally.
- [ ] Updated documentation.


## Screenshots <!-- If available -->
