### PR TITLE
fix(checkout form): credit cards icons having no explicit width

### DIFF
--- a/src/SubComponents/StripeElements.js
+++ b/src/SubComponents/StripeElements.js
@@ -115,7 +115,7 @@ export const CheckoutForm = () => {
         <PelcroCardNumber autoFocus={true} />
         <img
           alt="credit_cards"
-          className="plc-h-4 plc-mt-2"
+          className="plc-h-4 plc-w-auto plc-mt-2"
           src="https://js.pelcro.com/ui/plugin/main/images/credit_cards.png"
         />
 


### PR DESCRIPTION
## Description

- fix credit cards image in checkout form not having an explicitly set width.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->
- [x] Tested changes locally.

## Screenshots

### problem on production
![Untitled](https://user-images.githubusercontent.com/18618809/127028667-73e8d6a4-8905-4b71-8aeb-a6d7d5a0705b.png)

