### PR TITLE
fix(dashboard): close button not visible on Safari

### DIFF
--- a/src/Components/dashboard/Dashboard.js
+++ b/src/Components/dashboard/Dashboard.js
@@ -670,7 +670,7 @@ class Dashboard extends Component {
               <Button
                 variant="icon"
                 className="plc-text-gray-100 plc-w-7 plc-h-7"
-                icon={<XIcon />}
+                icon={<XIcon className="plc-w-7 plc-h-7" />}
                 onClick={this.closeDashboard}
               ></Button>
             </div>


### PR DESCRIPTION
## Description [[STORY LINK]](https://app.asana.com/0/1199393268587978/1200869657128758)

- fix dashboard close button not being visible on Safari

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [x] Tested changes locally.
- [ ] Updated documentation.
