### PR TITLE
fix(dashboard): plan text overflow

### DIFF
--- a/src/Components/dashboard/Dashboard.js
+++ b/src/Components/dashboard/Dashboard.js
@@ -295,7 +295,7 @@ class Dashboard extends Component {
             key={"dashboard-subscription-" + sub.id}
             className="plc-w-full plc-align-top"
           >
-            <td>
+            <td className="plc-truncate">
               {sub.plan.nickname && (
                 <>
                   <span className="plc-font-semibold plc-text-gray-500">
@@ -475,7 +475,7 @@ class Dashboard extends Component {
               <span className="plc-text-xs">{recipient.email}</span>
             </td>
             {/* Plan info section */}
-            <td>
+            <td className="plc-truncate">
               {recipient.plan.nickname && (
                 <>
                   <span className="plc-font-semibold plc-text-gray-500">


### PR DESCRIPTION
## Description [[STORY LINK]](https://app.asana.com/0/1199393268587978/1200826533747638)

- fix overflowing plan name text under gifts and subscriptions sections

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [x] Tested changes locally.
![Untitled](https://user-images.githubusercontent.com/18618809/132517987-82557ab9-85ae-49f2-8673-fd8c0e555520.png)


## Screenshots
