### PR TITLE
feat(gift create and redeem):use payment success modal not native alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [2.2.0-beta.20](https://github.com/pelcro-inc/react-pelcro-js/compare/v2.2.0-beta.19...v2.2.0-beta.20) (2021-09-21)
+
+
+### Bug Fixes
+
+* **i18n:** french wording nesting ([d03dbf6](https://github.com/pelcro-inc/react-pelcro-js/commit/d03dbf6401550ad2fd9e8f7783c6174b07d4b235))
+
 # [2.2.0-beta.19](https://github.com/pelcro-inc/react-pelcro-js/compare/v2.2.0-beta.18...v2.2.0-beta.19) (2021-09-20)
 
 

--- a/src/Components/AddressCreate/AddressCreateContainer.js
+++ b/src/Components/AddressCreate/AddressCreateContainer.js
@@ -178,7 +178,6 @@ const AddressCreateContainer = ({
                 return onFailure(err);
               }
 
-              alert(t("messages.subRedeemed"));
               return onGiftRedemptionSuccess(res);
             }
           );

--- a/src/Components/AddressCreate/AddressCreateContainer.js
+++ b/src/Components/AddressCreate/AddressCreateContainer.js
@@ -155,6 +155,11 @@ const AddressCreateContainer = ({
           set({ selectedAddressId: newAddressId });
         }
 
+        if (!giftCode) {
+          dispatch({ type: LOADING, payload: false });
+          return onSuccess(newAddressId);
+        }
+
         if (giftCode) {
           window.Pelcro.subscription.redeemGift(
             {
@@ -182,9 +187,6 @@ const AddressCreateContainer = ({
             }
           );
         }
-
-        dispatch({ type: LOADING, payload: false });
-        return onSuccess(newAddressId);
       }
     );
   };

--- a/src/Components/AddressCreate/AddressCreateModal.js
+++ b/src/Components/AddressCreate/AddressCreateModal.js
@@ -13,7 +13,7 @@ export const AddressCreateModal = ({
   onClose,
   ...otherProps
 }) => {
-  const { resetView, switchToPaymentView } = usePelcro();
+  const { switchView, switchToPaymentView } = usePelcro();
 
   const onSuccess = (newAddressId) => {
     otherProps.onSuccess?.(newAddressId);
@@ -23,7 +23,7 @@ export const AddressCreateModal = ({
 
   const onGiftRedemptionSuccess = () => {
     otherProps.onGiftRedemptionSuccess?.();
-    resetView();
+    switchView("subscription-success");
   };
 
   return (

--- a/src/Components/AddressSelect/AddressSelectContainer.js
+++ b/src/Components/AddressSelect/AddressSelectContainer.js
@@ -90,7 +90,6 @@ const AddressSelectContainer = ({
           return onFailure(err);
         }
 
-        alert(t("messages.subRedeemed"));
         return onGiftRedemptionSuccess(res);
       }
     );

--- a/src/Components/AddressSelect/AddressSelectModal.js
+++ b/src/Components/AddressSelect/AddressSelectModal.js
@@ -13,7 +13,7 @@ export const AddressSelectModal = ({
   onClose,
   ...otherProps
 }) => {
-  const { switchView, resetView, switchToPaymentView } = usePelcro();
+  const { switchView, switchToPaymentView } = usePelcro();
 
   const onSuccess = (selectedAddressId) => {
     otherProps.onSuccess?.(selectedAddressId);
@@ -23,7 +23,7 @@ export const AddressSelectModal = ({
 
   const onGiftRedemptionSuccess = () => {
     otherProps.onGiftRedemptionSuccess?.();
-    resetView();
+    switchView("subscription-success");
   };
 
   const onAddNewAddress = () => {

--- a/src/Components/PaymentSuccess/PaymentSuccessView.js
+++ b/src/Components/PaymentSuccess/PaymentSuccessView.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../SubComponents/Button";
 import { ReactComponent as CheckMark } from "../../assets/check-solid.svg";
@@ -6,17 +6,15 @@ import { usePelcro } from "../../hooks/usePelcro";
 
 export const PaymentSuccessView = ({ onClose }) => {
   const { t } = useTranslation("success");
-  const { product } = usePelcro();
+  const { successTitle, successContent } = getSuccessWording(t);
 
-  if (product) {
+  if (successTitle && successContent) {
     return (
       <div className="plc-flex plc-flex-col plc-items-center">
         <CheckMark className="plc-w-32 plc-my-4 plc-text-green-500" />
         <div className="plc-text-center plc-text-gray-900">
-          <h4 className="plc-mb-4 plc-text-3xl">
-            {product.paywall.success_title}
-          </h4>
-          <p>{product.paywall.success_content}</p>
+          <h4 className="plc-mb-4 plc-text-3xl">{successTitle}</h4>
+          <p>{successContent}</p>
         </div>
         <Button
           className="plc-mt-6"
@@ -29,4 +27,40 @@ export const PaymentSuccessView = ({ onClose }) => {
     );
   }
   return null;
+};
+
+const getCurrentFlow = () => {
+  const { product, giftRecipient, giftCode } = usePelcro.getStore();
+
+  if (giftRecipient) {
+    return "giftCreate";
+  } else if (giftCode) {
+    return "giftRedeem";
+  } else if (product) {
+    return "subscriptionSuccess";
+  }
+};
+
+const getSuccessWording = (i18n) => {
+  const flow = getCurrentFlow();
+  const { product, giftRecipient } = usePelcro.getStore();
+
+  const wordingDictionary = {
+    subscriptionSuccess: {
+      successTitle: product?.paywall?.success_title,
+      successContent: product?.paywall?.success_content
+    },
+    giftCreate: {
+      successTitle: i18n("messages.giftCreate.title"),
+      successContent: i18n("messages.giftCreate.content", {
+        email: giftRecipient?.email
+      })
+    },
+    giftRedeem: {
+      successTitle: i18n("messages.giftRedeem.title"),
+      successContent: i18n("messages.giftRedeem.content")
+    }
+  };
+
+  return wordingDictionary[flow];
 };

--- a/src/Components/SubscriptionCreate/SubscriptionCreateModal.js
+++ b/src/Components/SubscriptionCreate/SubscriptionCreateModal.js
@@ -19,20 +19,11 @@ export function SubscriptionCreateModal({
   ...otherProps
 }) {
   const { t } = useTranslation("common");
-  const { switchView, resetView, giftRecipient } = usePelcro();
+  const { switchView } = usePelcro();
 
   const onSuccess = (res) => {
     otherProps.onSuccess?.(res);
     trackSubscriptionOnGA();
-
-    if (giftRecipient) {
-      window.alert(
-        `${t("confirm.giftSent")} ${giftRecipient.email} ${t(
-          "confirm.successfully"
-        )}`
-      );
-      return resetView();
-    }
 
     return switchView("subscription-success");
   };

--- a/src/Components/dashboard/Dashboard.js
+++ b/src/Components/dashboard/Dashboard.js
@@ -109,8 +109,6 @@ class Dashboard extends Component {
 
   cancelSubscription = (subscription_id, onSuccess, onFailure) => {
     // disable the Login button to prevent repeated clicks
-    this.setState({ disableSubmit: true });
-
     window.Pelcro.subscription.cancel(
       {
         auth_token: window.Pelcro.user.read().auth_token,
@@ -120,8 +118,6 @@ class Dashboard extends Component {
         if (err) {
           return onFailure?.(err);
         }
-
-        this.setState({ disableSubmit: false });
 
         ReactGA?.event?.({
           category: "ACTIONS",
@@ -273,10 +269,18 @@ class Dashboard extends Component {
               this.cancelSubscription(sub.id, onSuccess, onFailure);
             },
             {
-              confirm: this.locale("labels.isSureToCancel"),
-              loading: "Cancelling your subscription",
-              success: "Subscription is successfully cancelled",
-              error: "Error cancelling your subscription"
+              confirmMessage: this.locale(
+                "messages.subCancellation.isSureToCancel"
+              ),
+              loadingMessage: this.locale(
+                "messages.subCancellation.loading"
+              ),
+              successMessage: this.locale(
+                "messages.subCancellation.success"
+              ),
+              errorMessage: this.locale(
+                "messages.subCancellation.error"
+              )
             }
           );
         };

--- a/src/SubComponents/Notification.css
+++ b/src/SubComponents/Notification.css
@@ -12,14 +12,14 @@
   }
 
   .pelcro-root .pelcro-notification-loading {
-    @apply plc-space-x-4 plc-text-sm plc-font-semibold plc-text-white plc-bg-green-500;
+    @apply plc-space-x-4 plc-text-sm plc-font-semibold;
   }
 
   .pelcro-root .pelcro-notification-warning {
-    @apply plc-font-semibold plc-text-sm plc-bg-yellow-500 plc-text-white;
+    @apply plc-text-sm plc-font-semibold plc-text-white plc-bg-yellow-500;
   }
 
   .pelcro-root .pelcro-notification-entitlement {
-    @apply plc-font-semibold plc-text-sm plc-bg-white plc-text-gray-600 plc-border-t-8 plc-border-primary-500;
+    @apply plc-text-sm plc-font-semibold plc-text-gray-600 plc-bg-white plc-border-t-8 plc-border-primary-500;
   }
 }

--- a/src/SubComponents/Notification.css
+++ b/src/SubComponents/Notification.css
@@ -1,9 +1,17 @@
 @layer components {
   .pelcro-root .pelcro-notification-error {
-    @apply plc-font-semibold plc-text-sm plc-bg-red-500  plc-text-white;
+    @apply plc-text-sm plc-font-semibold plc-text-white plc-bg-red-500;
   }
 
   .pelcro-root .pelcro-notification-success {
-    @apply plc-font-semibold plc-text-sm plc-bg-green-500 plc-text-white;
+    @apply plc-text-sm plc-font-semibold plc-text-white plc-bg-green-500;
+  }
+
+  .pelcro-root .pelcro-notification-confirm {
+    @apply plc-space-x-4 plc-text-sm plc-font-semibold plc-bg-white;
+  }
+
+  .pelcro-root .pelcro-notification-loading {
+    @apply plc-space-x-4 plc-text-sm plc-font-semibold plc-text-white plc-bg-green-500;
   }
 }

--- a/src/SubComponents/Notification.js
+++ b/src/SubComponents/Notification.js
@@ -1,11 +1,17 @@
 import React from "react";
-import { default as toast, ToastBar, Toaster } from "react-hot-toast";
+import {
+  default as toast,
+  ToastBar,
+  Toaster,
+  resolveValue
+} from "react-hot-toast";
 import { ReactComponent as CheckIcon } from "../assets/check-solid.svg";
 import { ReactComponent as XIcon } from "../assets/x-icon.svg";
 import { ReactComponent as SolidXIcon } from "../assets/x-icon-solid.svg";
 import { ReactComponent as SolidExclamationIcon } from "../assets/exclamation.svg";
 import { ReactComponent as SpinnerIcon } from "../assets/spinner.svg";
 import { Button } from "./Button";
+import i18n from "../i18n";
 
 export const Notification = ({ children, ...otherProps }) => {
   return (
@@ -14,7 +20,7 @@ export const Notification = ({ children, ...otherProps }) => {
       toastOptions={{
         success: {
           className: "pelcro-notification-success",
-          icon: <CheckIcon className="plc-w-24 plc-h-8" />,
+          icon: <CheckIcon className="plc-w-20 plc-h-8" />,
           iconTheme: {
             primary: "white",
             secondary: "green"
@@ -31,23 +37,18 @@ export const Notification = ({ children, ...otherProps }) => {
         confirm: {
           className: "pelcro-notification-confirm",
           icon: (
-            <SolidExclamationIcon className="plc-w-10 plc-h-10" />
+            <SolidExclamationIcon className="plc-w-20 plc-h-8 plc-text-red-500" />
           ),
-          iconTheme: {
-            primary: "white",
-            secondary: "red"
-          },
-          duration: Infinity
+          duration: Infinity,
+          hideCloseButton: true
         },
         loading: {
           className: "pelcro-notification-loading",
           icon: (
-            <SpinnerIcon className="plc-w-10 plc-h-10 plc-animate-spin" />
+            <SpinnerIcon className="plc-w-8 plc-h-8 plc-animate-spin" />
           ),
-          iconTheme: {
-            primary: "white",
-            secondary: "red"
-          }
+          duration: Infinity,
+          hideCloseButton: true
         }
       }}
       {...otherProps}
@@ -58,10 +59,12 @@ export const Notification = ({ children, ...otherProps }) => {
             <>
               {icon}
               {message}
-              <XIcon
-                className="plc-w-10 plc-h-5 plc-cursor-pointer"
-                onClick={() => toast.dismiss(t.id)}
-              />
+              {!t.hideCloseButton && (
+                <XIcon
+                  className="plc-w-10 plc-h-5 plc-cursor-pointer"
+                  onClick={() => toast.dismiss(t.id)}
+                />
+              )}
             </>
           )}
         </ToastBar>
@@ -83,31 +86,33 @@ toast.warning = (msg, options) =>
     ...options
   });
 
-export const notify = toast;
-
-notify.confirm = (
+toast.confirm = (
   onConfirm,
-  { confirm, loading, success, error },
+  { confirmMessage, loadingMessage, successMessage, errorMessage },
   options
 ) => {
-  const id = notify(
+  const translations = i18n.t("notification:confirm", {
+    returnObjects: true
+  });
+
+  const id = toast(
     (t) => (
       <div className="plc-space-y-4">
-        <p>{confirm}</p>
+        <p className="plc-font-semibold">{confirmMessage}</p>
         <div className="plc-space-y-2 sm:plc-space-y-0 sm:plc-space-x-2">
           <Button
             variant="solid"
-            className="plc-text-xs"
+            className="plc-text-xs plc-bg-red-500 hover:plc-bg-red-600"
             onClick={onConfirmClick}
           >
-            Confirm
+            {translations.labels.confirm}
           </Button>
           <Button
             className="plc-text-xs"
             variant="outline"
-            onClick={() => notify.dismiss(t.id)}
+            onClick={() => toast.dismiss(t.id)}
           >
-            Close
+            {translations.labels.close}
           </Button>
         </div>
       </div>
@@ -124,23 +129,25 @@ notify.confirm = (
   };
 
   const onLoading = () => {
-    notify.loading(loading, {
+    toast.loading(loadingMessage, {
       id,
       ...options
     });
   };
 
-  const onSuccess = () => {
-    notify.success(success, {
+  const onSuccess = (successValue) => {
+    toast.success(resolveValue(successMessage, successValue), {
       id,
       ...options
     });
   };
 
-  const onFailure = () => {
-    notify.error(error, {
+  const onFailure = (errorValue) => {
+    toast.error(resolveValue(errorMessage, errorValue), {
       id,
       ...options
     });
   };
 };
+
+export const notify = toast;

--- a/src/SubComponents/Notification.js
+++ b/src/SubComponents/Notification.js
@@ -2,6 +2,9 @@ import React from "react";
 import { default as toast, Toaster } from "react-hot-toast";
 import { ReactComponent as CheckIcon } from "../assets/check-solid.svg";
 import { ReactComponent as XIcon } from "../assets/x-icon-solid.svg";
+import { ReactComponent as SolidExclamationIcon } from "../assets/exclamation.svg";
+import { ReactComponent as SpinnerIcon } from "../assets/spinner.svg";
+import { Button } from "./Button";
 
 export const Notification = ({ children, ...otherProps }) => {
   return (
@@ -23,6 +26,27 @@ export const Notification = ({ children, ...otherProps }) => {
             primary: "white",
             secondary: "red"
           }
+        },
+        confirm: {
+          className: "pelcro-notification-confirm",
+          icon: (
+            <SolidExclamationIcon className="plc-w-10 plc-h-10" />
+          ),
+          iconTheme: {
+            primary: "white",
+            secondary: "red"
+          },
+          duration: Infinity
+        },
+        loading: {
+          className: "pelcro-notification-loading",
+          icon: (
+            <SpinnerIcon className="plc-w-10 plc-h-10 plc-animate-spin" />
+          ),
+          iconTheme: {
+            primary: "white",
+            secondary: "red"
+          }
         }
       }}
       {...otherProps}
@@ -35,3 +59,63 @@ export const Notification = ({ children, ...otherProps }) => {
 Notification.viewId = "notification";
 
 export const notify = toast;
+
+notify.confirm = (
+  onConfirm,
+  { confirm, loading, success, error },
+  options
+) => {
+  const id = notify(
+    (t) => (
+      <div className="plc-space-y-4">
+        <p>{confirm}</p>
+        <div className="plc-space-y-2 sm:plc-space-y-0 sm:plc-space-x-2">
+          <Button
+            variant="solid"
+            className="plc-text-xs"
+            onClick={onConfirmClick}
+          >
+            Confirm
+          </Button>
+          <Button
+            className="plc-text-xs"
+            variant="outline"
+            onClick={() => notify.dismiss(t.id)}
+          >
+            Close
+          </Button>
+        </div>
+      </div>
+    ),
+    {
+      type: "confirm",
+      ...options
+    }
+  );
+
+  const onConfirmClick = () => {
+    onLoading();
+    onConfirm(onSuccess, onFailure);
+  };
+
+  const onLoading = () => {
+    notify.loading(loading, {
+      id,
+      ...options
+    });
+  };
+
+  const onSuccess = () => {
+    notify.success(success, {
+      id,
+      ...options
+    });
+  };
+
+  const onFailure = () => {
+    notify.error(error, {
+      id,
+      ...options
+    });
+  };
+};

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -38,6 +38,8 @@ import dashboard_en from "./translations/en/dashboard.json";
 import dashboard_fr from "./translations/fr/dashboard.json";
 import select_en from "./translations/en/select.json";
 import select_fr from "./translations/fr/select.json";
+import notification_en from "./translations/en/notification.json";
+import notification_fr from "./translations/fr/notification.json";
 import { getCanonicalLocaleFormat } from "./utils/utils";
 
 const resources = {
@@ -60,7 +62,8 @@ const resources = {
     shop: shop_en,
     payment: payment_en,
     dashboard: dashboard_en,
-    select: select_en
+    select: select_en,
+    notification: notification_en
   },
   "fr-CA": {
     common: common_fr,
@@ -81,7 +84,8 @@ const resources = {
     shop: shop_fr,
     payment: payment_fr,
     dashboard: dashboard_fr,
-    select: select_fr
+    select: select_fr,
+    notification: notification_fr
   }
 };
 

--- a/src/translations/en/dashboard.json
+++ b/src/translations/en/dashboard.json
@@ -37,7 +37,6 @@
     "expiresOn": "Ends",
     "renewsOn": "Renews",
     "canceledOn": "Canceled on",
-    "isSureToCancel": "Are you sure you want to cancel your subscription?",
     "recipient": "Recipient",
     "addAddress": "Add address",
     "addSubscription": "New Subscription",
@@ -60,6 +59,12 @@
     }
   },
   "messages": {
-    "noCard": "You don't have a card"
+    "noCard": "You don't have a card",
+    "subCancellation": {
+      "isSureToCancel": "Are you sure you want to cancel your subscription?",
+      "loading": "Cancelling your subscription",
+      "success": "Subscription is successfully cancelled",
+      "error": "Error while cancelling your subscription"
+    }
   }
 }

--- a/src/translations/en/notification.json
+++ b/src/translations/en/notification.json
@@ -1,0 +1,8 @@
+{
+  "confirm": {
+    "labels": {
+      "confirm": "confirm",
+      "close": "close"
+    }
+  }
+}

--- a/src/translations/en/success.json
+++ b/src/translations/en/success.json
@@ -1,18 +1,26 @@
 {
-    "labels": {
-        "continue": "Continue to content"
+  "labels": {
+    "continue": "Continue to content"
+  },
+  "messages": {
+    "yourFreeTrial": "Subscription successful!",
+    "youHaveAccess": "Hope you enjoy the subscription. Please contact us if you have any questions or concerns.",
+    "clickToLearn": {
+      "click": "Click",
+      "here": "here",
+      "toLearn": "to learn more or contact us at",
+      "forQuestion": "for any questions."
     },
-    "messages": {
-        "yourFreeTrial": "Subscription successful!",
-        "youHaveAccess": "Hope you enjoy the subscription. Please contact us if you have any questions or concerns.",
-        "clickToLearn": {
-            "click": "Click",
-            "here": "here",
-            "toLearn": "to learn more or contact us at",
-            "forQuestion": "for any questions."
-        }
+    "giftCreate": {
+      "title": "Your Gift has been sent",
+      "content": "The gift will be sent to {{email}} on the date you specified."
     },
-    "errors": {
-        "": ""
+    "giftRedeem": {
+      "title": "Congratulations",
+      "content": "You have successfully redeemed your gift subscription. Enjoy!"
     }
+  },
+  "errors": {
+    "": ""
+  }
 }

--- a/src/translations/en/success.json
+++ b/src/translations/en/success.json
@@ -12,7 +12,7 @@
       "forQuestion": "for any questions."
     },
     "giftCreate": {
-      "title": "Your Gift has been sent",
+      "title": "Your gift has been sent",
       "content": "The gift will be sent to {{email}} on the date you specified."
     },
     "giftRedeem": {

--- a/src/translations/fr/dashboard.json
+++ b/src/translations/fr/dashboard.json
@@ -37,7 +37,6 @@
     "expiresOn": "Expire le",
     "renewsOn": "Renouvelle le",
     "canceledOn": "Annulé le",
-    "isSureToCancel": "Êtes-vous certain de vouloir annuler votre abonnement ?",
     "recipient": "Destinataire",
     "addAddress": "Ajoutez l'adresse",
     "addSubscription": "Nouvel abonnement",
@@ -60,6 +59,12 @@
     }
   },
   "messages": {
-    "noCard": "Vous n’avez pas une carte"
+    "noCard": "Vous n’avez pas une carte",
+    "subCancellation": {
+      "isSureToCancel": "Are you sure you want to cancel your subscription?",
+      "loading": "Cancelling your subscription",
+      "success": "Subscription is successfully cancelled",
+      "error": "Error while cancelling your subscription"
+    }
   }
 }

--- a/src/translations/fr/notification.json
+++ b/src/translations/fr/notification.json
@@ -1,0 +1,8 @@
+{
+  "confirm": {
+    "labels": {
+      "confirm": "confirmer",
+      "close": "close"
+    }
+  }
+}

--- a/src/translations/fr/success.json
+++ b/src/translations/fr/success.json
@@ -1,18 +1,26 @@
 {
-    "labels": {
-        "continue": "Abonnement réussi !"
+  "labels": {
+    "continue": "Abonnement réussi !"
+  },
+  "messages": {
+    "yourFreeTrial": "Votre essai gratuit vient de débuter",
+    "youHaveAccess": "Nous espérons que vous allez apprécier votre abonnement. Veuillez nous contacter si vous avez des questions ou des préoccupations.",
+    "clickToLearn": {
+      "click": "cliquez",
+      "here": "ici",
+      "toLearn": "pour en savoir plus ou contactez-nous à",
+      "forQuestion": "pour toute question."
     },
-    "messages": {
-        "yourFreeTrial": "Votre essai gratuit vient de débuter",
-        "youHaveAccess": "Nous espérons que vous allez apprécier votre abonnement. Veuillez nous contacter si vous avez des questions ou des préoccupations.",
-        "clickToLearn": {
-            "click": "cliquez",
-            "here": "ici",
-            "toLearn": "pour en savoir plus ou contactez-nous à",
-            "forQuestion": "pour toute question."
-        }
+    "giftCreate": {
+      "title": "Your Gift has been sent",
+      "content": "Le cadeau d’abonnement a été envoyé à {{email}} avec succès."
     },
-    "errors": {
-        "": ""
+    "giftRedeem": {
+      "title": "Congratulations",
+      "content": "You have successfully redeemed your gift subscription. Enjoy!"
     }
+  },
+  "errors": {
+    "": ""
+  }
 }


### PR DESCRIPTION
## feat(gift create and redeem): use payment success modal instead of native alerts
<!--- Describe your changes in detail here -->

This PR changes 4 main things

- [x] Make PaymentSuccessModal  smart. And change wording based on flow. 
- [x] Get rid of native alerts in favor of the already existing PaymentSuccessModal.
- [x] Add a new `notify.confirm` toast that can async handle any confirmation flow.
- [x] Use `notify.confirm` in the subscription cancelation flow instead of the native confirm. 
- [x] Fix a hidden bug with address creation in case of gift code existing. 

PS. French wording is not final yet. Waiting on that before closing the PR

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [x] Tested changes locally.
- [ ] Updated documentation.

## Screenshots <!-- If available -->
Gift creation success
![localhost_3000_ (48)](https://user-images.githubusercontent.com/6924756/135350942-f3b0e6ea-cd98-4a47-9edc-23964417ef65.png)



Gift redeem success
![localhost_3000__view=redeem gift_code=SBBMVUP6OR](https://user-images.githubusercontent.com/6924756/135350927-683d18de-2bf9-40b7-9508-7eb89d9b22bd.png)



Cancelation flow

Happy scenario 

https://user-images.githubusercontent.com/6924756/135347919-c448f38f-6186-40cc-9f78-a5ee3eae0edd.mp4


Failure scenario

https://user-images.githubusercontent.com/6924756/135347890-d446285b-971e-41c9-925c-338af6c57448.mp4



