### PR TITLE
feat(dashboard): use phase sensitive dates in subscription section

### DIFF
--- a/src/Components/Login/LoginView.js
+++ b/src/Components/Login/LoginView.js
@@ -42,15 +42,17 @@ export function LoginView(props) {
             required
             label={t("labels.password")}
           />
-          <Link
-            className="plc-flex plc-items-end plc-justify-end plc-text-sm plc-cursor-default plc-h-9"
-            id="pelcro-link-forgot-password"
-            onClick={props.onForgotPassword}
-          >
-            <span className="plc-cursor-pointer">
-              {t("messages.forgotPassword")}
-            </span>
-          </Link>
+          <div className="plc-flex plc-flex-row-reverse">
+            <Link
+              className="plc-inline-flex plc-items-end plc-text-sm plc-cursor-default plc-h-9"
+              id="pelcro-link-forgot-password"
+              onClick={props.onForgotPassword}
+            >
+              <span className="plc-cursor-pointer">
+                {t("messages.forgotPassword")}
+              </span>
+            </Link>
+          </div>
           <LoginButton
             role="submit"
             className="plc-w-full plc-mt-2"

--- a/src/Components/PaymentSuccess/PaymentSuccessView.js
+++ b/src/Components/PaymentSuccess/PaymentSuccessView.js
@@ -2,16 +2,18 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../SubComponents/Button";
 import { ReactComponent as CheckMark } from "../../assets/check-solid.svg";
+import { ReactComponent as GiftIcon } from "../../assets/gift.svg";
 import { usePelcro } from "../../hooks/usePelcro";
 
 export const PaymentSuccessView = ({ onClose }) => {
   const { t } = useTranslation("success");
-  const { successTitle, successContent } = getSuccessWording(t);
+  const { successTitle, successContent, successIcon } =
+    getSuccessContent(t);
 
   if (successTitle && successContent) {
     return (
       <div className="plc-flex plc-flex-col plc-items-center">
-        <CheckMark className="plc-w-32 plc-my-4 plc-text-green-500" />
+        {successIcon}
         <div className="plc-text-center plc-text-gray-900">
           <h4 className="plc-mb-4 plc-text-3xl">{successTitle}</h4>
           <p>{successContent}</p>
@@ -41,22 +43,31 @@ const getCurrentFlow = () => {
   }
 };
 
-const getSuccessWording = (i18n) => {
+const getSuccessContent = (i18n) => {
   const flow = getCurrentFlow();
   const { product, giftRecipient } = usePelcro.getStore();
 
   const wordingDictionary = {
     subscriptionSuccess: {
+      successIcon: (
+        <CheckMark className="plc-w-32 plc-my-4 plc-text-green-500" />
+      ),
       successTitle: product?.paywall?.success_title,
       successContent: product?.paywall?.success_content
     },
     giftCreate: {
+      successIcon: (
+        <GiftIcon className="plc-w-32 plc-my-4 plc-text-gray-400" />
+      ),
       successTitle: i18n("messages.giftCreate.title"),
       successContent: i18n("messages.giftCreate.content", {
         email: giftRecipient?.email
       })
     },
     giftRedeem: {
+      successIcon: (
+        <CheckMark className="plc-w-32 plc-my-4 plc-text-green-500" />
+      ),
       successTitle: i18n("messages.giftRedeem.title"),
       successContent: i18n("messages.giftRedeem.content")
     }

--- a/src/Components/PaymentSuccess/PaymentSuccessView.js
+++ b/src/Components/PaymentSuccess/PaymentSuccessView.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../SubComponents/Button";
 import { ReactComponent as CheckMark } from "../../assets/check-solid.svg";

--- a/src/Components/dashboard/Dashboard.js
+++ b/src/Components/dashboard/Dashboard.js
@@ -181,14 +181,27 @@ class Dashboard extends Component {
     }
 
     if (subscription.cancel_at_period_end) {
-      return `${this.locale("labels.expiresOn")} ${
-        subscription.current_period_end
-      }`;
+      // DateTime from BE is missing 3 zeros so we add them before instancing a date
+      const expiryDate = new Date(
+        Number(`${subscription.expires_at}000`)
+      );
+      const formattedExpiryDate = new Intl.DateTimeFormat(
+        "en-CA"
+      ).format(expiryDate);
+
+      return `${this.locale(
+        "labels.expiresOn"
+      )} ${formattedExpiryDate}`;
     }
 
-    return `${this.locale("labels.renewsOn")} ${
-      subscription.current_period_end
-    }`;
+    const renewDate = new Date(
+      Number(`${subscription.renews_at}000`)
+    );
+    const formattedRenewDate = new Intl.DateTimeFormat(
+      "en-CA"
+    ).format(renewDate);
+
+    return `${this.locale("labels.renewsOn")} ${formattedRenewDate}`;
   };
 
   reactivateSubscription = (subscription_id) => {

--- a/src/translations/en/notification.json
+++ b/src/translations/en/notification.json
@@ -1,8 +1,8 @@
 {
   "confirm": {
     "labels": {
-      "confirm": "confirm",
-      "close": "close"
+      "confirm": "Confirm",
+      "close": "Close"
     }
   }
 }

--- a/src/translations/fr/dashboard.json
+++ b/src/translations/fr/dashboard.json
@@ -61,10 +61,10 @@
   "messages": {
     "noCard": "Vous n’avez pas une carte",
     "subCancellation": {
-      "isSureToCancel": "Are you sure you want to cancel your subscription?",
-      "loading": "Cancelling your subscription",
-      "success": "Subscription is successfully cancelled",
-      "error": "Error while cancelling your subscription"
+      "isSureToCancel": "Êtes-vous certain de vouloir annuler votre abonnement?",
+      "loading": "Annulation de l'abonnement",
+      "success": "L'abonnement a été annulé avec succès",
+      "error": "Une erreure s'est produite lors de l'annulation de l'abonnement"
     }
   }
 }

--- a/src/translations/fr/notification.json
+++ b/src/translations/fr/notification.json
@@ -1,8 +1,8 @@
 {
   "confirm": {
     "labels": {
-      "confirm": "confirmer",
-      "close": "close"
+      "confirm": "Confirmer",
+      "close": "Fermer"
     }
   }
 }

--- a/src/translations/fr/success.json
+++ b/src/translations/fr/success.json
@@ -12,12 +12,12 @@
       "forQuestion": "pour toute question."
     },
     "giftCreate": {
-      "title": "Your Gift has been sent",
+      "title": "Votre cadeau a été envoyé",
       "content": "Le cadeau d’abonnement a été envoyé à {{email}} avec succès."
     },
     "giftRedeem": {
-      "title": "Congratulations",
-      "content": "You have successfully redeemed your gift subscription. Enjoy!"
+      "title": "Félicitations",
+      "content": "Vous avez validé votre abonnement cadeau. Profitez-en!"
     }
   },
   "errors": {


### PR DESCRIPTION
## Description [[STORY LINK]]()

<!--- Describe your changes in detail here -->
This PR includes a change in the dashboard UI where we're using current_period_end instead of the actual expiry date of the sub.
This fixes that and also adds some missing French wording.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [ ] Tested changes locally.
- [ ] Updated documentation.

## Screenshots <!-- If available -->
