### PR TITLE
fix(address): stale state select field when update country select field

### DIFF
--- a/src/Components/AddressCreate/AddressCreateContainer.js
+++ b/src/Components/AddressCreate/AddressCreateContainer.js
@@ -213,13 +213,16 @@ const AddressCreateContainer = ({
             isStateLoading: true
           });
 
-        case GET_STATES_SUCCESS:
+        case GET_STATES_SUCCESS: {
+          const stateKeys = Object.keys(action.payload.states);
+
           return Update({
             ...state,
             states: action.payload,
+            state: stateKeys?.[0],
             isStateLoading: false
           });
-
+        }
         case SET_TEXT_FIELD:
           return Update({
             ...state,

--- a/src/Components/AddressUpdate/AddressUpdateContainer.js
+++ b/src/Components/AddressUpdate/AddressUpdateContainer.js
@@ -183,12 +183,21 @@ const AddressUpdateContainer = ({
             isStateLoading: true
           });
 
-        case GET_STATES_SUCCESS:
+        case GET_STATES_SUCCESS: {
+          const stateKeys = Object.keys(action.payload.states);
+          const isSelectedStatePartOfCountry = stateKeys?.includes?.(
+            state.state
+          );
+
           return Update({
             ...state,
             states: action.payload,
-            isStateLoading: false
+            isStateLoading: false,
+            ...(!isSelectedStatePartOfCountry && {
+              state: stateKeys?.[0]
+            })
           });
+        }
 
         case SET_TEXT_FIELD:
           return Update({


### PR DESCRIPTION
## Description [[STORY LINK]](https://app.asana.com/0/1171579081591079/1201123515815299/f)

<!--- Describe your changes in detail here -->
The address `state` field was being state if not changed manually.
STR:

1. Open the sandbox
2. Create a customer
3. Create an address
4. Edit the address and choose another country without changing the state
5. Check the Platform for the address details

The platform will have the new country with the old state.
This PR prevents that by setting the first state of any newly fetched country.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [ ] Tested changes locally.
- [ ] Updated documentation.

## Screenshots <!-- If available -->
