### PR TITLE
fix(select): next button disabled when go back and reselect same product

### DIFF
--- a/src/Components/Select/SelectModal.js
+++ b/src/Components/Select/SelectModal.js
@@ -249,6 +249,12 @@ class SelectModal extends Component {
         this.setState({ product: product });
         this.setState({ planList: product.plans });
         this.setState({ mode: "plan" });
+        const isSelectedPlanPartOfThisProduct =
+          this.state.plan?.product_id === Number(product.id);
+
+        if (isSelectedPlanPartOfThisProduct) {
+          this.setState({ disabled: false });
+        }
       }
     }
   };


### PR DESCRIPTION
## Description [[STORY LINK]](https://app.asana.com/0/1171579081591079/1201068270318092/f)

<!--- Describe your changes in detail here -->

## Types of changes
Steps: [Check the attached video]
Login with a user
Subscribe to plan
Click "Renew" on the current plan
Click "Back" in the selection modal
Click on the same product again 
Select the same plan again and click "Next" button

Actual Result: The "Next" button is disabled and user cannot submit payment
Expected Result: The user should be able to proceed to payment modal

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [x] Tested changes locally.
- [ ] Updated documentation.

## Screenshots <!-- If available -->
