### PR TITLE
fix(coupon): remove discount from price when coupon is removed

### DIFF
--- a/src/Components/PaymentMethod/PaymentMethodContainer.js
+++ b/src/Components/PaymentMethod/PaymentMethodContainer.js
@@ -205,6 +205,25 @@ const PaymentMethodContainerWithoutStripe = ({
       dispatch({ type: UPDATE_PAYMENT_REQUEST });
     };
 
+    if (couponCode?.trim() === "") {
+      dispatch({
+        type: SET_COUPON,
+        payload: null
+      });
+
+      dispatch({
+        type: SET_PERCENT_OFF,
+        payload: ""
+      });
+
+      dispatch({
+        type: SET_UPDATED_PRICE,
+        payload: null
+      });
+
+      dispatch({ type: UPDATE_PAYMENT_REQUEST });
+    }
+
     if (couponCode?.trim()) {
       dispatch({ type: DISABLE_COUPON_BUTTON, payload: true });
 
@@ -694,7 +713,7 @@ const PaymentMethodContainerWithoutStripe = ({
       // When price is 0, we allow submitting without card info
       if (
         updatedPrice === 0 &&
-        state.coupon?.duration === "forever"
+        state.couponObject?.duration === "forever"
       ) {
         return subscribe({}, state, dispatch);
       }
@@ -844,7 +863,7 @@ const PaymentMethodContainerWithoutStripe = ({
           );
 
         case SET_COUPON:
-          return Update({ ...state, coupon: action.payload });
+          return Update({ ...state, couponObject: action.payload });
 
         case SET_COUPON_ERROR:
           return Update({ ...state, couponError: action.payload });


### PR DESCRIPTION
## Description [[STORY LINK]](https://app.asana.com/0/1171579081591079/1201194129742522/f)

<!--- Describe your changes in detail here -->

After removing the coupon, the UI is still displaying the discounted values.

STR:
Open the sandbox
Try to subscribe or create an order
Enter a coupon code on payment page
Validate that it's available as per the order/order-summary endpoints
Remove the coupon
Check the UI

Actual result: Payment modal is still displaying the discounted price. Video
Expected result: The discounted price should be removed from the UI.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [x] Tested changes locally.
- [ ] Updated documentation.

## Screenshots <!-- If available -->

Before:


https://user-images.githubusercontent.com/6924756/138332652-645fdd07-c1a6-420a-ab83-ef1c669770f5.mp4



After:



https://user-images.githubusercontent.com/6924756/138332669-3e3dfa76-ff43-484f-a5ff-a97b1debf4a2.mp4


