### PR TITLE
feat: lazy load Stripe SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^0.3.0",
+    "@stripe/stripe-js": "^1.21.1",
     "i18next": "^19.1.0",
     "react-easy-crop": "^3.3.2",
     "react-facebook-login": "^4.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -50,7 +50,8 @@ export default [
             "isValidElementType",
             "ForwardRef",
             "typeOf"
-          ]
+          ],
+          "node_modules/@stripe/stripe-js/pure.js": ["loadStripe"]
         }
       }),
       del({ targets: ["dist/*"] }),

--- a/src/Components/PelcroModalController/PelcroModalController.service.js
+++ b/src/Components/PelcroModalController/PelcroModalController.service.js
@@ -7,6 +7,7 @@ import {
   isValidViewFromURL
 } from "../../utils/utils";
 import { init as initContentEntitlement } from "../common/contentEntitlement";
+import { loadStripe } from "@stripe/stripe-js/pure";
 
 /**
  * @typedef {Object} OptionsType
@@ -79,11 +80,13 @@ export const initPaywalls = () => {
 };
 
 export const loadPaymentSDKs = () => {
-  // Load stripe's SDK
-  window.Pelcro.helpers.loadSDK(
-    "https://js.stripe.com/v3/",
-    "pelcro-sdk-stripe-id"
-  );
+  // Lazy load stripe's SDK
+  const { whenUserReady } = usePelcro.getStore();
+  whenUserReady(() => {
+    if (!window.Stripe) {
+      loadStripe(window.Pelcro.environment.stripe);
+    }
+  });
 
   // Load PayPal SDK's
   const supportsPaypal = Boolean(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1930,6 +1930,11 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@stripe/stripe-js@^1.21.1":
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.21.1.tgz#e56cd01f889dc06af4a68ebf61d2492a87e80da1"
+  integrity sha512-/HhRol0Bia/6L7JstXUOpg3m0U3nBW8c2tvaBE6QdonN+OMusYT9AIqCMR/PyzoF3ROifFJ2kbWT7xQjbKN3tw==
+
 "@svgr/babel-plugin-add-jsx-attribute@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.4.0.tgz#81ef61947bb268eb9d50523446f9c638fb355906"


### PR DESCRIPTION
this is simply #99 done again after getting reverted, the only difference here is that we're now loading the SDK when the user is authenticated instead of loading it when payment modals are opened