### PR TITLE
fix(gift creation): error dispatched if gift date is set to today

### DIFF
--- a/src/Components/GiftCreate/GiftCreateContainer.js
+++ b/src/Components/GiftCreate/GiftCreateContainer.js
@@ -15,6 +15,7 @@ import {
   DISABLE_SUBMIT,
   SHOW_ALERT
 } from "../../utils/action-types";
+import { getDateWithoutTime } from "../../utils/utils";
 
 const initialState = {
   email: "",
@@ -62,11 +63,13 @@ const GiftCreateContainer = ({
     }
 
     if (giftRecipient.startDate) {
-      const nowDate = new Date();
-      const yearFromNowDate = new Date(
-        new Date().setFullYear(nowDate.getFullYear() + 1)
+      const nowDate = getDateWithoutTime(new Date());
+      const yearFromNowDate = getDateWithoutTime(
+        new Date(new Date().setFullYear(nowDate.getFullYear() + 1))
       );
-      const submittedDate = new Date(giftRecipient.startDate);
+      const submittedDate = getDateWithoutTime(
+        new Date(giftRecipient.startDate)
+      );
 
       if (
         submittedDate < nowDate ||

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -377,3 +377,14 @@ export const getPaymentCardIcon = (name) => {
     )
   );
 };
+
+/**
+ * Gets the current date with time set to 0
+ * @param {Date} dateObject
+ * @return {Date}
+ */
+export function getDateWithoutTime(dateObject) {
+  const date = new Date(dateObject.getTime());
+  date.setHours(0, 0, 0, 0);
+  return date;
+}


### PR DESCRIPTION
## Description [[STORY LINK]](https://app.asana.com/0/1171579081591079/1201338433165484/f)

<!--- Describe your changes in detail here -->
This PR fixes a bug with a false positive regarding time comparison on gift creation.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [ ] Tested changes locally.
- [ ] Updated documentation.

## Screenshots <!-- If available -->
![2021-11-08_13h48_23](https://user-images.githubusercontent.com/6924756/144062440-78f606e7-0c59-4d3d-9ba3-0144c31ba139.png)