### PR TITLE
feat: add expiremental security token support

### DIFF
--- a/src/Components/PelcroModalController/PelcroModalController.js
+++ b/src/Components/PelcroModalController/PelcroModalController.js
@@ -16,6 +16,7 @@ const defaultOptions = {
   enableURLTriggers: true,
   enableTheme: true,
   enablePaywalls: true,
+  loadSecuritySDK: true,
   enableGoogleAnalytics: false
 };
 

--- a/src/Components/PelcroModalController/PelcroModalController.service.js
+++ b/src/Components/PelcroModalController/PelcroModalController.service.js
@@ -33,6 +33,7 @@ export const optionsController = (options) => {
     enableURLTriggers: initViewFromURL,
     enableTheme: applyPelcroTheme,
     enablePaywalls: initPaywalls,
+    loadSecuritySDK: initSecuritySdk,
     enableGoogleAnalytics: initGATracking
   };
 
@@ -104,6 +105,19 @@ export const loadPaymentSDKs = () => {
       "braintree-paypal-sdk"
     );
   }
+};
+
+export const initSecuritySdk = () => {
+  const { whenSiteReady } = usePelcro.getStore();
+
+  whenSiteReady(() => {
+    const securityKey = window.Pelcro.site.read()?.security_key;
+    if (!securityKey) return;
+    window.Pelcro.helpers.loadSDK(
+      `https://www.google.com/recaptcha/enterprise.js?render=${securityKey}`,
+      "pelcro-security-enteprise"
+    );
+  });
 };
 
 export const initGATracking = () => {

--- a/src/Components/Register/RegisterButton.js
+++ b/src/Components/Register/RegisterButton.js
@@ -4,7 +4,12 @@ import { Button } from "../../SubComponents/Button";
 import { HANDLE_REGISTRATION } from "../../utils/action-types";
 import { store } from "./RegisterContainer";
 
-export const RegisterButton = ({ name, onClick, ...otherProps }) => {
+export const RegisterButton = ({
+  name,
+  onClick,
+  className,
+  ...otherProps
+}) => {
   const {
     state: {
       emailError,
@@ -38,6 +43,9 @@ export const RegisterButton = ({ name, onClick, ...otherProps }) => {
       }}
       disabled={isDisabled}
       isLoading={buttonDisabled}
+      className={`${className} g-recaptcha`}
+      data-action="register"
+      data-sitekey={window.Pelcro.site.read()?.security_key}
       {...otherProps}
     >
       {name ?? t("messages.createAccount")}


### PR DESCRIPTION
## Description [[STORY LINK]](https://app.asana.com/0/inbox/1199393268584848)

this is part of our second security token experiment, the goal is to move the logic from the SDK to the elements to see if this would solve the problem of getting incorrect assessments.

- Load security SDK if the site does have a proper `security_key` value as part of the GET site API call
- Add security token generation logic to the register container

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [x] Tested changes locally.
- [ ] Updated documentation.
