### PR TITLE
feat(select modal): emphasize a product if it matches page tag

### DIFF
--- a/src/Components/Select/SelectModal.js
+++ b/src/Components/Select/SelectModal.js
@@ -208,7 +208,6 @@ class SelectModal extends Component {
   };
 
   renderProducts = () => {
-    console.log("normal");
     const userDidSelectProduct = Boolean(this.state.mode === "plan");
     const productsToShow = userDidSelectProduct
       ? [this.state.product]

--- a/src/Components/Select/SelectModal.js
+++ b/src/Components/Select/SelectModal.js
@@ -241,16 +241,34 @@ class SelectModal extends Component {
           this.renderOneProduct(product, index, { emphasize: true })
         )}
 
-        <hr className="plc-my-4" />
+        {allProductsMinusMatched?.length > 0 && (
+          <>
+            <hr className="plc-my-4" />
 
-        <h3 className="plc-text-sm plc-font-semibold">
-          {this.locale("labels.restrictiveArticles.or")}
-        </h3>
-        {allProductsMinusMatched.map((product, index) =>
-          this.renderOneProduct(product, index)
+            <h3 className="plc-text-sm plc-font-semibold">
+              {this.locale("labels.restrictiveArticles.or")}
+            </h3>
+            {allProductsMinusMatched.map((product, index) =>
+              this.renderOneProduct(product, index)
+            )}
+          </>
         )}
       </div>
     );
+
+    function productsWithMatchedTaggedFirst() {
+      const allProducts = window.Pelcro.product.list() ?? [];
+      const productsThatMatchArticleTag =
+        window.Pelcro.product.getByMatchingPageTags();
+
+      const allProductsMinusMatched = allProducts.filter((product) =>
+        productsThatMatchArticleTag.find(
+          (matchedProduct) => matchedProduct.id !== product.id
+        )
+      );
+
+      return [productsThatMatchArticleTag, allProductsMinusMatched];
+    }
   };
 
   renderPlans = () => {
@@ -461,34 +479,3 @@ SelectModal.propTypes = {
 
 export const SelectModalWithTrans =
   withTranslation("select")(SelectModal);
-
-function getProductsThatMatchArticleTag() {
-  const productsThatMatchArticleTags = Pelcro.product
-    .list()
-    .filter((product) => product.paywall && product.paywall.tags)
-    .filter((productWithTags) => {
-      const articleTags = window.Pelcro.helpers.getOgArticleTags();
-      const productTags = productWithTags.paywall.tags.split(",");
-
-      // return intersection
-      return articleTags?.some((articleTag) =>
-        productTags.includes(articleTag)
-      );
-    });
-
-  return productsThatMatchArticleTags ?? [];
-}
-
-function productsWithMatchedTaggedFirst() {
-  const allProducts = window.Pelcro.product.list() ?? [];
-  const productsThatMatchArticleTag =
-    getProductsThatMatchArticleTag();
-
-  const allProductsMinusMatched = allProducts.filter((product) =>
-    productsThatMatchArticleTag.find(
-      (matchedProduct) => matchedProduct.id !== product.id
-    )
-  );
-
-  return [productsThatMatchArticleTag, allProductsMinusMatched];
-}

--- a/src/Components/Select/SelectModal.js
+++ b/src/Components/Select/SelectModal.js
@@ -145,67 +145,113 @@ class SelectModal extends Component {
     return `${startingPlan.amount_formatted}/${startingPlan.interval}`;
   };
 
+  renderOneProduct = (product, index, options) => {
+    const isPlanMode = Boolean(this.state.mode === "plan");
+    const productButtonLabel = isPlanMode
+      ? this.locale("buttons.back")
+      : this.locale("buttons.select");
+    const productButtonCallback = isPlanMode
+      ? this.goBack
+      : this.selectProduct;
+
+    return (
+      <div
+        key={product.id}
+        className={`plc-flex plc-items-start plc-p-2 plc-mt-4 plc-space-x-3 plc-text-gray-900 plc-border-solid plc-rounded plc-border-primary-500 pelcro-select-product-wrapper ${
+          options?.emphasize ? "plc-border-2" : "plc-border"
+        }`}
+      >
+        {product.image && (
+          <img
+            alt={`image of ${product.name}`}
+            src={product.image}
+            className="plc-object-contain plc-w-1/4 pelcro-select-product-image"
+          />
+        )}
+
+        <div
+          className={`plc-flex plc-flex-wrap ${
+            product.image ? "plc-w-3/4" : "plc-w-full"
+          }`}
+        >
+          <div className="plc-w-full pelcro-select-product-header">
+            <p className="plc-font-bold pelcro-select-product-title">
+              {product.name}
+            </p>
+            <p className="plc-text-xs pelcro-select-product-description">
+              {product.description}
+            </p>
+          </div>
+
+          <div className="plc-flex plc-items-end plc-w-full plc-mt-3">
+            {product.plans && (
+              <p className="plc-w-1/2 plc-text-xs pelcro-select-product-cost">
+                {this.locale("labels.startingAt")}{" "}
+                {this.countStartPrice(product.plans)}
+              </p>
+            )}
+            <Button
+              onClick={productButtonCallback}
+              data-key={product.id}
+              id="pelcro-select-product-back-button"
+              className={`plc-ml-auto plc-text-xs ${
+                options?.emphasize ? "plc-bg-primary-700" : ""
+              }`}
+              {...(index === 0 && { autoFocus: true })}
+            >
+              {productButtonLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   renderProducts = () => {
+    console.log("normal");
     const userDidSelectProduct = Boolean(this.state.mode === "plan");
     const productsToShow = userDidSelectProduct
       ? [this.state.product]
       : this.state.productList;
-    const productButtonLabel = userDidSelectProduct
-      ? this.locale("buttons.back")
-      : this.locale("buttons.select");
-    const productButtonCallback = userDidSelectProduct
-      ? this.goBack
-      : this.selectProduct;
 
-    return productsToShow.map((product, i) => {
-      return (
-        <div
-          key={product.id}
-          className="plc-flex plc-items-start plc-p-2 plc-mt-4 plc-space-x-3 plc-text-gray-900 plc-border plc-border-solid plc-rounded plc-border-primary-500 pelcro-select-product-wrapper"
-        >
-          {product.image && (
-            <img
-              alt={`image of ${product.name}`}
-              src={product.image}
-              className="plc-object-contain plc-w-1/4 pelcro-select-product-image"
-            />
-          )}
-
-          <div
-            className={`plc-flex plc-flex-wrap ${
-              product.image ? "plc-w-3/4" : "plc-w-full"
-            }`}
-          >
-            <div className="plc-w-full pelcro-select-product-header">
-              <p className="plc-font-bold pelcro-select-product-title">
-                {product.name}
-              </p>
-              <p className="plc-text-xs pelcro-select-product-description">
-                {product.description}
-              </p>
-            </div>
-
-            <div className="plc-flex plc-items-end plc-w-full plc-mt-3">
-              {product.plans && (
-                <p className="plc-w-1/2 plc-text-xs pelcro-select-product-cost">
-                  {this.locale("labels.startingAt")}{" "}
-                  {this.countStartPrice(product.plans)}
-                </p>
-              )}
-              <Button
-                onClick={productButtonCallback}
-                data-key={product.id}
-                id="pelcro-select-product-back-button"
-                className="plc-ml-auto plc-text-xs"
-                {...(i === 0 && { autoFocus: true })}
-              >
-                {productButtonLabel}
-              </Button>
-            </div>
-          </div>
-        </div>
-      );
+    return productsToShow.map((product, index) => {
+      return this.renderOneProduct(product, index);
     });
+  };
+
+  renderMatchingProductsFirst = () => {
+    const isPlanMode = Boolean(this.state.mode === "plan");
+    if (isPlanMode) {
+      return this.renderOneProduct(this.state.product);
+    }
+
+    const [productsThatMatchArticleTag, allProductsMinusMatched] =
+      productsWithMatchedTaggedFirst();
+
+    // Render normal products if there are no available matching products
+    if (!productsThatMatchArticleTag?.length) {
+      return this.renderProducts();
+    }
+
+    return (
+      <div>
+        <h3 className="plc-text-sm plc-font-semibold">
+          {this.locale("labels.restrictiveArticles.subscribeTo")}
+        </h3>
+        {productsThatMatchArticleTag.map((product, index) =>
+          this.renderOneProduct(product, index, { emphasize: true })
+        )}
+
+        <hr className="plc-my-4" />
+
+        <h3 className="plc-text-sm plc-font-semibold">
+          {this.locale("labels.restrictiveArticles.or")}
+        </h3>
+        {allProductsMinusMatched.map((product, index) =>
+          this.renderOneProduct(product, index)
+        )}
+      </div>
+    );
   };
 
   renderPlans = () => {
@@ -351,7 +397,10 @@ class SelectModal extends Component {
             </div>
 
             <div className="pelcro-select-products-wrapper">
-              {this.renderProducts()}
+              {window.Pelcro.site.read()
+                ?.restrictive_paywall_metatags_enabled
+                ? this.renderMatchingProductsFirst()
+                : this.renderProducts()}
             </div>
 
             {this.state.mode === "plan" && (
@@ -413,3 +462,34 @@ SelectModal.propTypes = {
 
 export const SelectModalWithTrans =
   withTranslation("select")(SelectModal);
+
+function getProductsThatMatchArticleTag() {
+  const productsThatMatchArticleTags = Pelcro.product
+    .list()
+    .filter((product) => product.paywall && product.paywall.tags)
+    .filter((productWithTags) => {
+      const articleTags = window.Pelcro.helpers.getOgArticleTags();
+      const productTags = productWithTags.paywall.tags.split(",");
+
+      // return intersection
+      return articleTags?.some((articleTag) =>
+        productTags.includes(articleTag)
+      );
+    });
+
+  return productsThatMatchArticleTags ?? [];
+}
+
+function productsWithMatchedTaggedFirst() {
+  const allProducts = window.Pelcro.product.list() ?? [];
+  const productsThatMatchArticleTag =
+    getProductsThatMatchArticleTag();
+
+  const allProductsMinusMatched = allProducts.filter((product) =>
+    productsThatMatchArticleTag.find(
+      (matchedProduct) => matchedProduct.id !== product.id
+    )
+  );
+
+  return [productsThatMatchArticleTag, allProductsMinusMatched];
+}

--- a/src/translations/en/select.json
+++ b/src/translations/en/select.json
@@ -15,7 +15,11 @@
     },
     "selectProduct": "Select a product",
     "selectPlan": "Select a plan",
-    "startingAt": "Starting at"
+    "startingAt": "Starting at",
+    "restrictiveArticles": {
+      "subscribeTo": "Subscribe to one of the following options to get access to this page",
+      "or": "Or take a look at some of our other options below"
+    }
   },
   "buttons": {
     "next": "Next",

--- a/src/translations/fr/select.json
+++ b/src/translations/fr/select.json
@@ -15,7 +15,11 @@
     },
     "selectProduct": "Sélectionnez un produit",
     "selectPlan": "Sélectionnez un plan",
-    "starningAt": "À partir de"
+    "starningAt": "À partir de",
+    "restrictiveArticles": {
+      "subscribeTo": "Subscribe to one of the following options to get access to this page",
+      "or": "Or take a look at some of our other options below"
+    }
   },
   "buttons": {
     "next": "Prochain",

--- a/src/translations/fr/select.json
+++ b/src/translations/fr/select.json
@@ -17,8 +17,8 @@
     "selectPlan": "Sélectionnez un plan",
     "starningAt": "À partir de",
     "restrictiveArticles": {
-      "subscribeTo": "Subscribe to one of the following options to get access to this page",
-      "or": "Or take a look at some of our other options below"
+      "subscribeTo": "Abonnez-vous à une des options suivantes pour accéder au contenu de cette page",
+      "or": "Sinon, jetez un coup d'oeil à d'autres offres ci-dessous"
     }
   },
   "buttons": {


### PR DESCRIPTION
## Description [[STORY LINK]](https://app.asana.com/0/750497957484456/1201211241835323/f)

<!--- Describe your changes in detail here -->
A problem that we have with the tagged paywall feature is the user will have no idea which product to subscribe to if they are paywalled on an article, which product will unlock this article? 

This PR adds an approach to emphasize the products/plans which will unlock the article:

"Subscribe to one of the following options to get access to this page"
Product A
Product B
—————————————————
"Or take a look at some of our other options below:"
Product C

In case there is no matching product, we render the normal product list.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [x] Tested changes locally.
- [ ] Updated documentation.

## Screenshots <!-- If available -->

![image](https://user-images.githubusercontent.com/6924756/150380822-cdf80656-0b7a-4653-9de2-25f84cb4d1dd.png)

