### PR TITLE
fix(register): failing if site already uses grecaptcha outside pelcro

### DIFF
--- a/src/Components/Register/RegisterContainer.js
+++ b/src/Components/Register/RegisterContainer.js
@@ -272,6 +272,8 @@ export { RegisterContainer, store };
  * @return {boolean}
  */
 function hasSecurityTokenEnabled() {
-  const hasSecuritySdkLoaded = Boolean(window.grecaptcha);
+  const hasSecuritySdkLoaded = Boolean(
+    window.Pelcro.site.read()?.security_key
+  );
   return hasSecuritySdkLoaded;
 }


### PR DESCRIPTION
## Description [[STORY LINK]](https://app.asana.com/0/1200020643413862/1201708304620013/f)

- fix a bug where sites that already use grecaptcha are being treated as sites that use pelcro's grecaptcha integration even if they don't

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [ ] Tested changes locally.
- [ ] Updated documentation.
