### PR TITLE
Feature/set to default props

### DIFF
--- a/src/Components/PaymentMethod/PaymentMethodView.js
+++ b/src/Components/PaymentMethod/PaymentMethodView.js
@@ -46,7 +46,8 @@ export function PaymentMethodView({
   showOrderButton,
   showApplePayButton,
   order,
-  subCreateMetadata
+  subCreateMetadata,
+  ...props
 }) {
   const { t } = useTranslation("checkoutForm");
   const { plan, isAuthenticated } = usePelcro();
@@ -192,6 +193,7 @@ export function PaymentMethodView({
                 <PaymentMethodUpdateSetDefault
                   id="pelcro-input-is-default"
                   label={t("labels.isDefault")}
+                  {...props}
                 />
               )}
 

--- a/src/Components/PaymentMethodUpdate/PaymentMethodUpdateSetDefault.js
+++ b/src/Components/PaymentMethodUpdate/PaymentMethodUpdateSetDefault.js
@@ -13,16 +13,16 @@ export function PaymentMethodUpdateSetDefault(props) {
     state: { isDefault }
   } = useContext(store);
 
-  const { paymentMethodToEdit } = usePelcro();
+  const { paymentMethodToEdit, paymentMethodDefaultChecked } = usePelcro();
 
   useEffect(() => {
-    if (paymentMethodToEdit?.is_default) {
+    if (paymentMethodToEdit?.is_default || paymentMethodDefaultChecked) {
       dispatch({
         type: SET_IS_DEFAULT_PAYMENT_METHOD,
         payload: { isDefault: true }
       });
     }
-  }, [paymentMethodToEdit]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [paymentMethodToEdit, paymentMethodDefaultChecked]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleCheckboxChange = (e) => {
     dispatch({

--- a/src/Components/PaymentMethodUpdate/PaymentMethodUpdateSetDefault.js
+++ b/src/Components/PaymentMethodUpdate/PaymentMethodUpdateSetDefault.js
@@ -13,16 +13,16 @@ export function PaymentMethodUpdateSetDefault(props) {
     state: { isDefault }
   } = useContext(store);
 
-  const { paymentMethodToEdit, paymentMethodDefaultChecked } = usePelcro();
+  const { paymentMethodToEdit } = usePelcro();
 
   useEffect(() => {
-    if (paymentMethodToEdit?.is_default || paymentMethodDefaultChecked) {
+    if (paymentMethodToEdit?.is_default || props?.paymentMethodDefaultChecked) {
       dispatch({
         type: SET_IS_DEFAULT_PAYMENT_METHOD,
         payload: { isDefault: true }
       });
     }
-  }, [paymentMethodToEdit, paymentMethodDefaultChecked]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [paymentMethodToEdit, props?.paymentMethodDefaultChecked]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleCheckboxChange = (e) => {
     dispatch({

--- a/src/Components/PaymentMethodUpdate/PaymentMethodUpdateView.js
+++ b/src/Components/PaymentMethodUpdate/PaymentMethodUpdateView.js
@@ -25,6 +25,7 @@ export function PaymentMethodUpdateView(props) {
         onDisplay={props.onDisplay}
         onFailure={props.onFailure}
         onSuccess={props.onSuccess}
+        {...props}
       />
     </div>
   );


### PR DESCRIPTION
## Description [[Default Payment Method Enhancement]]()

<!--- Describe your changes in detail here -->

I’ve added a new prop for the PaymentMethodUpdateModal:
`<PaymentMethodUpdateModal paymentMethodDefaultChecked={true} />`
You can set this prop to true to have the checkbox for "set as default" checked when changing the card. 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [x] Tested changes locally.
- [ ] Updated documentation.


## Screenshots <!-- If available -->
<img width="510" alt="Screenshot 2024-10-30 at 4 41 02 PM" src="https://github.com/user-attachments/assets/874bcc0c-557a-4cff-ad35-341575f88fa7">
