### PR TITLE
feat: Add hidden setAsDefault

### DIFF
--- a/src/Components/PaymentMethod/PaymentMethodContainer.js
+++ b/src/Components/PaymentMethod/PaymentMethodContainer.js
@@ -1875,7 +1875,8 @@ const PaymentMethodContainerWithoutStripe = ({
           window.Pelcro.paymentMethods.create(
             {
               auth_token: window.Pelcro.user.read().auth_token,
-              token: result.paymentMethod.id
+              token: result.paymentMethod.id,
+              is_default: props?.hiddenSetAsDefault ? true : false
             },
             (err, res) => {
               if (err) {

--- a/src/Components/PaymentMethod/PaymentMethodView.js
+++ b/src/Components/PaymentMethod/PaymentMethodView.js
@@ -45,7 +45,7 @@ export function PaymentMethodView({
   showOrderButton,
   showApplePayButton,
   order,
-  ...props
+
 }) {
   const { t } = useTranslation("checkoutForm");
   const cardProcessor = getSiteCardProcessor();

--- a/src/Components/PaymentMethod/PaymentMethodView.js
+++ b/src/Components/PaymentMethod/PaymentMethodView.js
@@ -45,7 +45,7 @@ export function PaymentMethodView({
   showOrderButton,
   showApplePayButton,
   order,
-
+  ...props
 }) {
   const { t } = useTranslation("checkoutForm");
   const cardProcessor = getSiteCardProcessor();

--- a/src/Components/PaymentMethod/PaymentMethodView.js
+++ b/src/Components/PaymentMethod/PaymentMethodView.js
@@ -44,7 +44,8 @@ export function PaymentMethodView({
   showSubscriptionButton,
   showOrderButton,
   showApplePayButton,
-  order
+  order,
+  ...props
 }) {
   const { t } = useTranslation("checkoutForm");
   const cardProcessor = getSiteCardProcessor();
@@ -116,6 +117,7 @@ export function PaymentMethodView({
           onGiftRenewalSuccess={onGiftRenewalSuccess}
           onFailure={onFailure}
           freeOrders={showOrderButton}
+          {...props}
         >
           <AlertWithContext className="plc-mb-2" />
           {/* Payment form */}

--- a/src/Components/PaymentMethodCreate/PaymentMethodCreateView.js
+++ b/src/Components/PaymentMethodCreate/PaymentMethodCreateView.js
@@ -15,6 +15,7 @@ export function PaymentMethodCreateView(props) {
         onDisplay={props.onDisplay}
         onFailure={props.onFailure}
         onSuccess={props.onSuccess}
+        {...props}
       />
     </div>
   );

--- a/src/Components/PaymentMethodUpdate/PaymentMethodUpdateSetDefault.js
+++ b/src/Components/PaymentMethodUpdate/PaymentMethodUpdateSetDefault.js
@@ -16,7 +16,10 @@ export function PaymentMethodUpdateSetDefault(props) {
   const { paymentMethodToEdit } = usePelcro();
 
   useEffect(() => {
-    if (paymentMethodToEdit?.is_default) {
+    if (
+      paymentMethodToEdit?.is_default ||
+      props?.hiddenSetAsDefault
+    ) {
       dispatch({
         type: SET_IS_DEFAULT_PAYMENT_METHOD,
         payload: { isDefault: true }
@@ -31,7 +34,9 @@ export function PaymentMethodUpdateSetDefault(props) {
     });
   };
 
-  return (
+  return props?.hiddenSetAsDefault ? (
+    <></>
+  ) : (
     <Checkbox
       onChange={(e) => handleCheckboxChange(e)}
       id={props.id}

--- a/src/Components/PaymentMethodUpdate/PaymentMethodUpdateView.js
+++ b/src/Components/PaymentMethodUpdate/PaymentMethodUpdateView.js
@@ -12,6 +12,7 @@ export function PaymentMethodUpdateView(props) {
         onDisplay={props.onDisplay}
         onFailure={props.onFailure}
         onSuccess={props.onSuccess}
+        {...props}
       />
     </div>
   );


### PR DESCRIPTION
## Mark credit cards as "default" [[STORY LINK](https://app.asana.com/0/1208552045376881/1208723569237892/f)]

- Adding prop hiddenSetAsDefaul for PaymentMethodUpdateModal  to be able to set any updated card as default without showing set as default check box.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [x] Tested changes locally.
- [ ] Updated documentation.
