### PR TITLE
feat: display carousel for items length at least 2

### DIFF
--- a/src/Components/Select/SelectModal.js
+++ b/src/Components/Select/SelectModal.js
@@ -1,23 +1,23 @@
-import React, { Component } from "react";
 import PropTypes from "prop-types";
+import React, { Component } from "react";
+import ReactGA from "react-ga";
+import ReactGA4 from "react-ga4";
 import { withTranslation } from "react-i18next";
+import { Button } from "../../SubComponents/Button";
+import { Carousel } from "../../SubComponents/Carousel";
+import ImageSelect from "../../SubComponents/ImageSelect";
 import {
   Modal,
-  ModalHeader,
   ModalBody,
-  ModalFooter
+  ModalFooter,
+  ModalHeader
 } from "../../SubComponents/Modal";
-import { Button } from "../../SubComponents/Button";
-import ImageSelect from "../../SubComponents/ImageSelect";
-import { Carousel } from "../../SubComponents/Carousel";
-import { usePelcro } from "../../hooks/usePelcro";
 import { ReactComponent as ArrowLeft } from "../../assets/arrow-left.svg";
+import { usePelcro } from "../../hooks/usePelcro";
 import {
   getEntitlementsFromElem,
   notifyBugsnag
 } from "../../utils/utils";
-import ReactGA from "react-ga";
-import ReactGA4 from "react-ga4";
 
 /**
  *
@@ -119,7 +119,8 @@ class SelectModal extends Component {
         ? window.Pelcro.product.getByEntitlements(
             props.matchingEntitlements
           )
-        : window.Pelcro.product.list()
+        : window.Pelcro.product.list(),
+      windowWidth: window.innerWidth
     };
 
     this.product =
@@ -131,7 +132,13 @@ class SelectModal extends Component {
     this.enableReactGA4 = window?.Pelcro?.uiSettings?.enableReactGA4;
   }
 
+  updateWindowWidth = () => {
+    this.setState({ windowWidth: window.innerWidth });
+  };
+
   componentDidMount = () => {
+    window.addEventListener("resize", this.updateWindowWidth);
+
     if (this.props.product) {
       const { product } = this.props;
       const planList = product.plans;
@@ -232,6 +239,7 @@ class SelectModal extends Component {
 
   componentWillUnmount = () => {
     document.removeEventListener("keydown", this.handleSubmit);
+    window.removeEventListener("resize", this.updateWindowWidth);
   };
 
   handleSubmit = (e) => {
@@ -411,19 +419,26 @@ class SelectModal extends Component {
       this.renderOneProduct(product, index)
     );
 
-    if (items.length > 3) {
+    const isMobile = this.state.windowWidth < 768;
+    const shouldRenderCarousel =
+      items.length >= 2 && (isMobile || items.length > 2);
+
+    if (shouldRenderCarousel) {
       return (
-        <Carousel slidesCount={items.length} mobileArrowDown={true}>
+        <Carousel
+          slidesCount={items.length}
+          mobileArrowDown={isMobile}
+        >
           {items}
         </Carousel>
       );
-    } else {
-      return (
-        <div className="plc-flex plc-flex-col md:plc-flex-row plc-gap-4 plc-items-center sm:plc-px-8 plc-px-0">
-          {items}
-        </div>
-      );
     }
+
+    return (
+      <div className="plc-flex plc-flex-col md:plc-flex-row plc-gap-4 plc-items-center sm:plc-px-8 plc-px-0">
+        {items}
+      </div>
+    );
   };
 
   handleScrollLeft = () => {

--- a/src/SubComponents/Carousel.js
+++ b/src/SubComponents/Carousel.js
@@ -1,7 +1,7 @@
-import React, { useRef, useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import Slider from "react-slick";
-import { ReactComponent as ArrowThinRight } from "../assets/arrow-thin-right.svg";
 import { ReactComponent as ArrowThinLeft } from "../assets/arrow-thin-left.svg";
+import { ReactComponent as ArrowThinRight } from "../assets/arrow-thin-right.svg";
 
 const NextArrow = ({
   onClick,
@@ -80,7 +80,6 @@ export function Carousel({
   }, [initialSlide]);
 
   const settings = {
-    dots: true,
     infinite: false,
     speed: 200,
     slidesToShow: slidesToShow,


### PR DESCRIPTION
## Description [[STORY LINK]]()

<!--- Describe your changes in detail here -->

- Update the logic of `select-modal` so that it displays items in a carousel when there are at least 2 items, instead of 3 as it did previously.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)e)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [x] Tested changes locally.
- [ ] Updated documentation.

## Screenshots <!-- If available -->

![image](https://github.com/user-attachments/assets/a3c6694d-81bf-4bfe-bd94-4867db05dbc2)