### PR TITLE
fix: image select options font change

### DIFF
--- a/src/SubComponents/ImageSelect.css
+++ b/src/SubComponents/ImageSelect.css
@@ -32,3 +32,11 @@
   display: flex;
   align-items: center;
 }
+
+.menu-list {
+  font-family: "Lato", system-ui, -apple-system,
+    /* Firefox supports this but not yet `system-ui` */
+    "Segoe UI",
+    Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji";
+}

--- a/src/SubComponents/ImageSelect.js
+++ b/src/SubComponents/ImageSelect.js
@@ -49,6 +49,9 @@ const ImageSelect = ({ optionsArray, ...props }) => {
           Option: customOption,
           SingleValue: customSingleValue
         }}
+        classNames={{
+          menuList: () => "menu-list"
+        }}
         {...props}
         menuPortalTarget={document.body}
         styles={{


### PR DESCRIPTION
## Description [[STORY LINK]]()

Bring back old font for `ImageSelectOptions`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [x] Tested changes locally.
- [ ] Updated documentation.

## Screenshots <!-- If available -->
Before:
![image](https://github.com/user-attachments/assets/522a48df-e32f-4623-bdf3-08fd042ed28c)

After:
![image](https://github.com/user-attachments/assets/4e1a0de1-2b83-43a8-87e3-7a78c22710f0)
