### PR TITLE
fix: handle cases where no default payment method exists

### DIFF
--- a/src/Components/PaymentMethodSelect/PaymentMethodSelectContainer.js
+++ b/src/Components/PaymentMethodSelect/PaymentMethodSelectContainer.js
@@ -12,8 +12,17 @@ import {
 } from "../../utils/action-types";
 
 const moveDefaultPaymentMethodToStart = (paymentMethods) => {
-  const defaultPaymentMethod =
-    getDefaultPaymentMethod(paymentMethods);
+  if (!paymentMethods || !Array.isArray(paymentMethods)) {
+    return [];
+  }
+
+  const defaultPaymentMethod = getDefaultPaymentMethod(paymentMethods);
+  
+  // If no default payment method exists, return the original array
+  if (!defaultPaymentMethod) {
+    return paymentMethods;
+  }
+
   const paymentMethodsWithoutDefault = paymentMethods.filter(
     (paymentMethod) => paymentMethod.id !== defaultPaymentMethod.id
   );
@@ -26,9 +35,22 @@ const moveDefaultPaymentMethodToStart = (paymentMethods) => {
 };
 
 const getDefaultPaymentMethod = (paymentMethods) => {
+  if (!paymentMethods || !Array.isArray(paymentMethods)) {
+    return null;
+  }
+  
+  // First try to find a payment method marked as default
   const defaultPaymentMethod = paymentMethods.find(
     (paymentMethod) => paymentMethod.is_default
   );
+
+  // If no default is found, return the first chargeable payment method
+  if (!defaultPaymentMethod) {
+    return paymentMethods.find(
+      (paymentMethod) => paymentMethod.status === "chargeable"
+    );
+  }
+
   return defaultPaymentMethod;
 };
 


### PR DESCRIPTION
## Description [[STORY LINK]]()

This PR fixes an issue where the payment method selection component throws an error when no default payment method exists. The error "Cannot read properties of undefined (reading 'id')" was occurring because the code wasn't properly handling cases where a user has payment methods but none are marked as default.

## Types of changes

- Added null checks for payment methods array to prevent undefined errors
- Added fallback to first chargeable payment method when no default exists
- Improved error handling in moveDefaultPaymentMethodToStart function
- Added input validation to ensure payment methods is a valid array

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the points, and put an 'x' in all the boxes that are done (if it doesn't apply on the change, remove the box) -->

- [ ] Tested changes locally.
- [ ] Updated documentation.

## Screenshots <!-- If available -->
