### PR TITLE
fix: handle undefined default payment method

### DIFF
--- a/src/Components/PaymentMethodSelect/PaymentMethodSelectContainer.js
+++ b/src/Components/PaymentMethodSelect/PaymentMethodSelectContainer.js
@@ -12,8 +12,12 @@ import {
 } from "../../utils/action-types";
 
 const moveDefaultPaymentMethodToStart = (paymentMethods) => {
-  const defaultPaymentMethod =
-    getDefaultPaymentMethod(paymentMethods);
+  const defaultPaymentMethod = getDefaultPaymentMethod(paymentMethods);
+  
+  if (!defaultPaymentMethod) {
+    return paymentMethods;
+  }
+
   const paymentMethodsWithoutDefault = paymentMethods.filter(
     (paymentMethod) => paymentMethod.id !== defaultPaymentMethod.id
   );


### PR DESCRIPTION
## Description [[STORY LINK]]()

This PR fixes an issue where the payment method selection component throws a "Cannot read properties of undefined (reading 'id')" error when no default payment method exists. The error occurs in the `moveDefaultPaymentMethodToStart` function when trying to filter payment methods using a non-existent default payment method.

### Changes Made:
- Added null check for default payment method before filter operation
- Return original payment methods array when no default exists
- Maintain original behavior for cases where default payment method exists

### Testing:
- Verified that the component works when:
  - User has a default payment method
  - User has payment methods but none are default
  - User has no payment methods

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] Tested changes locally.
- [] Updated documentation.

## Screenshots
N/A - This is a bug fix with no UI changes