### PR TITLE
feat: screen freeze fix

### DIFF
--- a/src/Components/PaymentMethod/PaymentMethodContainer.js
+++ b/src/Components/PaymentMethod/PaymentMethodContainer.js
@@ -4103,15 +4103,21 @@ const PaymentMethodContainer = (props) => {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    let cancelled = false;
     whenUserReady(() => {
       if (!window.Stripe && cardProcessor === "stripe") {
-        document
-          .querySelector('script[src="https://js.stripe.com/v3"]')
-          .addEventListener("load", () => {
-            setIsStripeLoaded(true);
-          });
+        loadStripe(window.Pelcro.environment.stripe)
+          .then(() => {
+            if (!cancelled) setIsStripeLoaded(true);
+          })
+          .catch((err) =>
+            console.error("Failed to load Stripe.js", err)
+          );
       }
     });
+    return () => {
+      cancelled = true;
+    };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (isStripeLoaded) {

--- a/src/Components/PelcroModalController/PelcroModalController.service.js
+++ b/src/Components/PelcroModalController/PelcroModalController.service.js
@@ -804,11 +804,9 @@ const showPaymentMethodUpdateFromUrl = () => {
       );
 
       if (!window.Stripe && !supportsVantiv && !supportsTap) {
-        document
-          .querySelector('script[src="https://js.stripe.com/v3"]')
-          .addEventListener("load", () => {
-            return switchView("payment-method-update");
-          });
+        loadStripe(window.Pelcro.environment.stripe)
+          .then(() => switchView("payment-method-update"))
+          .catch((err) => console.error("Failed to load Stripe.js", err));
         return;
       }
 


### PR DESCRIPTION

## Description — [JCP] Screen Freezes When Adding Payment Method via URL Trigger (Authenticated User) - 212962

Fixes a screen-freeze bug for authenticated users hitting `?view=payment-method-update` on any Stripe-only client (reported on Johnson County Post).

**Root cause**

Two locations in the SDK queried for the Stripe script with an exact-match selector:
```js
document.querySelector('script[src="https://js.stripe.com/v3"]').addEventListener("load", cb)
```
However, `@stripe/stripe-js/pure`'s `injectScript` always appends `?advancedFraudSignals=false` to the src (`pure.js:41–43`). The exact-match selector returns `null` → `null.addEventListener(...)` throws `TypeError` → `setIsStripeLoaded(true)` is never called → `PaymentMethodContainer` returns `null` while `<body>` retains `pelcro-modal-open` (`overflow:hidden`) → user sees a blank, scroll-locked page.

Auth-only because the unauthenticated path returns `switchView("login")` before reaching the broken selector. Race-dependent but reliable on cold loads (Stripe.js is ~200KB and rarely beats the `whenUserReady` callback).

**Fix**

Replace both broken DOM-selector patterns with `loadStripe(...).then(...)` — the loader's promise resolves after `window.Stripe` is populated, eliminating the URL-format coupling and the null-pointer race entirely. Both files already imported `loadStripe`; `loadStripe` is idempotent (caches its promise), so re-calling is safe.

**Files changed:**
- `src/Components/PelcroModalController/PelcroModalController.service.js` — `showPaymentMethodUpdateFromUrl`
- `src/Components/PaymentMethod/PaymentMethodContainer.js` — mount `useEffect`

**Defensive additions** (no behavioral impact beyond the bug fix):
- `.catch(err => console.error(...))` so Stripe load failures surface in Sentry instead of being silently swallowed
- Unmount cleanup flag in `PaymentMethodContainer`'s `useEffect` to avoid stale `setState` if the component unmounts before the promise resolves

**Impact:**
- Affected: every Stripe-only client on a `react-pelcro-js` version containing the broken selector (latent crash on `?view=payment-method-update` cold loads — particularly hit from "update your card" emails)
- Not affected: Vantiv / Tap clients (separate branches, untouched), the `window.Stripe`-already-loaded happy path (guard skips both branches), Meter / paywall / login flows

---

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

---

## Checklist
- [ ] Tested changes locally — **pending:** JCP staging (https://jcp.wxp.io/) is currently down (flagged by Abdelrahman on the Asana task). Will validate once staging is back up.

---

## Screenshots

N/A

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214064099329016