### PR TITLE
fix: guard window.braintree access against async SDK loading race

### DIFF
--- a/src/Components/PaymentMethod/PaymentMethodContainer.js
+++ b/src/Components/PaymentMethod/PaymentMethodContainer.js
@@ -63,7 +63,8 @@ import {
   getFourDigitYear,
   createBraintreeDropin,
   requestBraintreePaymentMethod,
-  requestBraintreeHostedFieldsPaymentMethod
+  requestBraintreeHostedFieldsPaymentMethod,
+  whenBraintreeReady
 } from "../common/Helpers";
 import {
   Payment,
@@ -1265,6 +1266,7 @@ const PaymentMethodContainerWithoutStripe = ({
           );
 
           // Initialize 3D Secure for additional security
+          await whenBraintreeReady(["threeDSecure"]);
           braintree3DSecureInstanceRef.current =
             new window.braintree.threeDSecure.create({
               version: 2,
@@ -1341,6 +1343,7 @@ const PaymentMethodContainerWithoutStripe = ({
         });
 
         try {
+          await whenBraintreeReady(["client", "hostedFields"]);
           const clientInstance =
             await new window.braintree.client.create({
               authorization: braintreeToken

--- a/src/Components/common/Helpers.js
+++ b/src/Components/common/Helpers.js
@@ -204,3 +204,37 @@ export function requestBraintreeHostedFieldsPaymentMethod(hostedFieldsInstance) 
     });
   });
 }
+
+/**
+ * Waits until the requested Braintree SDK modules are available on
+ * window.braintree. The Braintree scripts (client, hostedFields,
+ * threeDSecure, paypalCheckout, dropin) are loaded fire-and-forget by
+ * loadPaymentSDKs(), so consumers must defer access until each module
+ * finishes loading to avoid TypeError on slow connections.
+ *
+ * @param {string[]} modules - module names that must exist on window.braintree
+ * @param {number} [timeout=30000] - max wait in ms before rejecting
+ * @returns {Promise<typeof window.braintree>}
+ */
+export function whenBraintreeReady(modules, timeout = 30000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      if (
+        window.braintree &&
+        modules.every((m) => window.braintree[m])
+      ) {
+        return resolve(window.braintree);
+      }
+      if (Date.now() - start >= timeout) {
+        return reject(
+          new Error(
+            `Braintree SDK modules not ready after ${timeout}ms: ${modules.join(", ")}`
+          )
+        );
+      }
+      setTimeout(check, 100);
+    };
+    check();
+  });
+}

--- a/src/services/PayPal/PaypalCheckout.service.js
+++ b/src/services/PayPal/PaypalCheckout.service.js
@@ -2,6 +2,7 @@ import {
   getFormattedPriceByLocal,
   getPageOrDefaultLanguage
 } from "../../utils/utils";
+import { whenBraintreeReady } from "../../Components/common/Helpers";
 
 /**
  * @typedef {Object} paypalConstructorOptions
@@ -45,6 +46,13 @@ export class PaypalClient {
         "Braintree/Paypal integration is currently not enabled on this site's config"
       );
 
+      return;
+    }
+
+    try {
+      await whenBraintreeReady(["client", "paypalCheckout"]);
+    } catch (err) {
+      console.error("Braintree SDK failed to load for PayPal", err);
       return;
     }
 


### PR DESCRIPTION
<hr>
<h2>Description — <a href="https://app.asana.com/1/742417627358732/project/1201176291286264">Sentry Bug: Braintree client accessed before SDK loads — CUSTOM-UIS-H8</a></h2>
<p>The 5 Braintree SDK scripts (<code>client</code>, <code>hostedFields</code>, <code>threeDSecure</code>, <code>paypalCheckout</code>, <code>dropin</code>) are loaded fire-and-forget by <code>loadPaymentSDKs()</code>, so accessing <code>window.braintree.&lt;module&gt;</code> synchronously throws <code>TypeError</code> on slow connections — observed on JCP via Sentry CUSTOM-UIS-H8 (29 users / 34 events).</p>
<p>Added <code>whenBraintreeReady()</code> helper that polls <code>window.braintree.&lt;module&gt;</code> with a 30s timeout, then guarded the 5 access sites in <code>PaymentMethodContainer</code> and <code>PaypalCheckout.service</code> so each awaits the modules it actually uses.</p>
<p><strong>Root cause</strong></p>
<p><code>loadPaymentSDKs</code> (<code>PelcroModalController.service.js:131–159</code>) injects 5 separate Braintree scripts via <code>window.Pelcro.helpers.loadSDK(...)</code> in fire-and-forget mode — none awaited:</p>

Script | Sets on window.braintree
-- | --
client.min.js | client
paypal-checkout.min.js | paypalCheckout
three-d-secure.min.js | threeDSecure
dropin.js | dropin
hosted-fields.min.js | hostedFields


<p><strong>Happy path:</strong> when modules are already loaded (the common case), the helper resolves synchronously on the first poll-tick — zero perf overhead.</p>
<p><strong>Failure path:</strong> on timeout, the existing <code>try/catch</code> blocks (<code>PaymentMethodContainer.js:1292</code> and <code>:1384</code>) catch the rejection and reset the skeleton loader. PayPal's <code>build()</code> got a new local <code>try/catch</code> with an early return since it had no surrounding handler.</p>
<p><strong>Impact:</strong></p>
<ul>
<li>Fixes: every Braintree-enabled client (JCP + others). The Sentry signature <code>window.braintree.client</code> should stop appearing once consumers upgrade.</li>
<li>Unchanged: Stripe, Vantiv, Tap, Cybersource, Drop-in (already loaded via <code>loadBraintreeScript().then(...)</code>), meter, paywalls, login.</li>
<li>New observability: if Braintree's CDN fails (ad-blocker, network), Sentry will now surface <code>"Braintree SDK modules not ready after 30000ms: ..."</code> instead of a cryptic null-pointer crash.</li>
</ul>
<hr>
<h2>Types of Changes</h2>
<ul>
<li>[x] Bug fix (non-breaking change which fixes an issue)</li>
<li>[x] New feature (non-breaking change which adds functionality)</li>
</ul>
<hr>
<h2>Checklist</h2>
<ul>
<li>[ ] Tested changes locally — <strong>pending:</strong> JCP staging (https://jcp.wxp.io/) is currently unreachable. Will validate via codesandbox preview build (same workflow used for the screen-freeze fix on PR #477) once a JCP local env is wired to sandbox.</li>
</ul>
<hr>
<h2>Screenshots</h2>
<p>N/A — backend/SDK behavioral fix; no UI changes.</p></body></html>Here's the filled PR template:

