### PR TITLE
feat: Gifting Flow Improvement, Remove Repeated Coupon Prompt

### DIFF
--- a/src/Components/Login/LoginModal.js
+++ b/src/Components/Login/LoginModal.js
@@ -47,10 +47,9 @@ export function LoginModal({ onDisplay, onClose, ...props }) {
       return resetView();
     }
 
-    // If this is a redeem gift
+    // If this is a redeem gift, proceed to address (where redeemGift API is called)
     if (giftCode) {
-      return switchView("gift-redeem");
-      // return switchToAddressView();
+      return switchToAddressView();
     }
 
     // Check if the subscription is meant as a gift (if so, gather recipients info)

--- a/src/Components/Register/RegisterModal.js
+++ b/src/Components/Register/RegisterModal.js
@@ -62,10 +62,9 @@ export function RegisterModal(props) {
       return resetView();
     }
 
-    // If this is a redeem gift
+    // If this is a redeem gift, proceed to address (where redeemGift API is called)
     if (giftCode) {
-      return switchView("gift-redeem");
-      // return switchToAddressView();
+      return switchToAddressView();
     }
 
     // Check if the subscription is meant as a gift (if so, gather recipients info)


### PR DESCRIPTION
## Description — Fix: Gift Code Double-Entry on Registration/Login

Fixes the gift redemption flow where users were prompted to enter the gift code twice.

**Bug:** After a user entered a gift code and registered (or logged in), the gift-redeem modal opened again with an empty input, forcing them to re-enter the same code.

---

**Root Cause**

Both `RegisterModal.js` and `LoginModal.js` called `switchView("gift-redeem")` after authentication when `giftCode` was set in the store, instead of proceeding to the address step where `redeemGift()` is automatically invoked.

---

**Fix**

Replaced `switchView("gift-redeem")` with `switchToAddressView()` in both modals (the corrected line was already commented out in the code by the original author). After registration/login, the user now goes directly to the address step → `AddressCreateContainer` calls the `redeemGift` API with the stored `giftCode` and `address_id` → gift is redeemed successfully without re-prompting.

---

**Files Changed**

- `src/Components/Register/RegisterModal.js`
- `src/Components/Login/LoginModal.js`

---

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

---

## Checklist
- [x] Tested changes locally.

---

## Screenshots

N/A — flow change only, no UI changes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214111581901098