### PR TITLE
feat(i18n): add German (de) locale translations

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -117,6 +117,35 @@ import subscriptionCancel_es from "./translations/es/subscriptionCancel.json";
 import subscriptionManageMembers_es from "./translations/es/subscriptionManageMembers.json";
 import subscriptionSuspend_es from "./translations/es/subscriptionSuspend.json";
 
+import common_de from "./translations/de/common.json";
+import paymentMethod_de from "./translations/de/paymentMethod.json";
+import newsletter_de from "./translations/de/newsletter.json";
+import success_de from "./translations/de/success.json";
+import meter_de from "./translations/de/meter.json";
+import checkoutForm_de from "./translations/de/checkoutForm.json";
+import messages_de from "./translations/de/messages.json";
+import login_de from "./translations/de/login.json";
+import verifyLinkToken_de from "./translations/de/verifyLinkToken.json";
+import register_de from "./translations/de/register.json";
+import userEdit_de from "./translations/de/userEdit.json";
+import address_de from "./translations/de/address.json";
+import passwordReset_de from "./translations/de/passwordReset.json";
+import passwordForgot_de from "./translations/de/passwordForgot.json";
+import passwordChange_de from "./translations/de/passwordChange.json";
+import passwordlessRequest_de from "./translations/de/passwordlessRequest.json";
+import cart_de from "./translations/de/cart.json";
+import shop_de from "./translations/de/shop.json";
+import payment_de from "./translations/de/payment.json";
+import dashboard_de from "./translations/de/dashboard.json";
+import select_de from "./translations/de/select.json";
+import donation_de from "./translations/de/donation.json";
+import notification_de from "./translations/de/notification.json";
+import verifyEmail_de from "./translations/de/verifyEmail.json";
+import invoiceDetails_de from "./translations/de/InvoiceDetails.json";
+import subscriptionCancel_de from "./translations/de/subscriptionCancel.json";
+import subscriptionManageMembers_de from "./translations/de/subscriptionManageMembers.json";
+import subscriptionSuspend_de from "./translations/de/subscriptionSuspend.json";
+
 import { getPageOrDefaultLanguage } from "./utils/utils";
 
 const resources = {
@@ -239,6 +268,36 @@ const resources = {
     subscriptionCancel: subscriptionCancel_es,
     subscriptionSuspend: subscriptionSuspend_es,
     subscriptionManageMembers: subscriptionManageMembers_es
+  },
+  de: {
+    common: common_de,
+    paymentMethod: paymentMethod_de,
+    newsletter: newsletter_de,
+    success: success_de,
+    meter: meter_de,
+    checkoutForm: checkoutForm_de,
+    messages: messages_de,
+    login: login_de,
+    verifyLinkToken: verifyLinkToken_de,
+    register: register_de,
+    userEdit: userEdit_de,
+    address: address_de,
+    passwordReset: passwordReset_de,
+    passwordForgot: passwordForgot_de,
+    passwordChange: passwordChange_de,
+    passwordlessRequest: passwordlessRequest_de,
+    verifyEmail: verifyEmail_de,
+    cart: cart_de,
+    shop: shop_de,
+    payment: payment_de,
+    dashboard: dashboard_de,
+    select: select_de,
+    donation: donation_de,
+    notification: notification_de,
+    invoiceDetails: invoiceDetails_de,
+    subscriptionCancel: subscriptionCancel_de,
+    subscriptionSuspend: subscriptionSuspend_de,
+    subscriptionManageMembers: subscriptionManageMembers_de
   }
 };
 

--- a/src/translations/de/InvoiceDetails.json
+++ b/src/translations/de/InvoiceDetails.json
@@ -1,0 +1,14 @@
+{
+  "title": "Rechnungsdetails",
+  "labels": {
+    "summary": "Zusammenfassung",
+    "total": "Gesamt",
+    "amountPaid": "Bezahlter Betrag",
+    "amountDue": "Fälliger Betrag",
+    "creationDate": "Erstellt am:"
+  },
+  "buttons": {
+    "download": "Herunterladen",
+    "pay": "Jetzt bezahlen"
+  }
+}

--- a/src/translations/de/address.json
+++ b/src/translations/de/address.json
@@ -1,0 +1,26 @@
+{
+  "title": "Geben Sie Ihre Lieferadresse ein",
+  "titleGifting": "Geben Sie Ihre Adresse ein",
+  "selectAddressTitle": "Bitte wählen Sie eine Adresse aus",
+  "selectAddressSubtitle": "Wählen Sie eine Ihrer gespeicherten Adressen aus oder fügen Sie eine neue hinzu",
+  "labels": {
+    "address": "Adresse",
+    "code": "Postleitzahl",
+    "city": "Stadt",
+    "region": "Bundesland/Provinz/Region",
+    "country": "Land",
+    "firstName": "Vorname",
+    "lastName": "Nachname",
+    "required": "erforderlich",
+    "isDefault": "Als Standard festlegen"
+  },
+  "buttons": {
+    "submit": "Absenden",
+    "selectAddress": "Adresse auswählen",
+    "addAddress": "Neue Adresse hinzufügen"
+  },
+  "messages": {
+    "addressUpdated": "Die Adresse wurde erfolgreich aktualisiert!",
+    "subRedeemed": "Ihr Abonnement wurde eingelöst."
+  }
+}

--- a/src/translations/de/cart.json
+++ b/src/translations/de/cart.json
@@ -1,0 +1,13 @@
+{
+    "title": "Ihr Warenkorb",
+    "subtitle": "Schließen Sie Ihren Kauf unten ab",
+    "name": "Name",
+    "quantity": "Menge",
+    "price": "Preis",
+    "actions": "Aktionen",
+    "remove": "Entfernen",
+    "total": "Gesamt",
+    "confirm": "Zur Kasse",
+    "empty": "Ihr Warenkorb ist leer.",
+    "removeAll": "Alle entfernen"
+}

--- a/src/translations/de/checkoutForm.json
+++ b/src/translations/de/checkoutForm.json
@@ -1,0 +1,34 @@
+{
+  "messages": {
+    "youAreSafe": "Sie sind sicher - PCI-konform 128 SSL von",
+    "bankRedirection": "Bitte warten Sie, Sie werden zu Ihrer Bank weitergeleitet.",
+    "bankAuthenticationSuccess": "Bitte warten Sie, während wir Ihre Anfrage bearbeiten."
+  },
+  "labels": {
+    "card": "Kartennummer eingeben",
+    "date": "Ablaufdatum",
+    "CVC": "CVC",
+    "required": "erforderlich",
+    "submit": "Absenden",
+    "pay": "bezahlen",
+    "addCode": "Gutscheincode hinzufügen",
+    "hideCode": "Ausblenden",
+    "codePlaceholder": "Geben Sie Ihren Gutscheincode ein",
+    "applyCouponCode": "Anwenden",
+    "code": "Gutscheincode",
+    "for": "für",
+    "interval": "{{count}} {{interval}}",
+    "interval_plural": "{{count}} {{interval}}",
+    "tax": "Steuer",
+    "removeCoupon": "ENTFERNEN",
+    "firstName": "Vorname",
+    "lastName": "Nachname",
+    "phone": "Telefon",
+    "freeItems": "Kostenlose Artikel",
+    "order": "Bestellung",
+    "amount": "Betrag",
+    "email": "E-Mail",
+    "password": "Passwort",
+    "isDefault": "Als Standard festlegen"
+  }
+}

--- a/src/translations/de/common.json
+++ b/src/translations/de/common.json
@@ -1,0 +1,93 @@
+{
+  "validation": {
+    "validEmail": "Die E-Mail-Adresse ist ungültig.",
+    "validUsername": "Der Benutzername ist ungültig.",
+    "enterEmail": "E-Mail-Adresse ist erforderlich.",
+    "enterEmails": "E-Mail-Adressen sind erforderlich.",
+    "enterUsername": "Benutzername ist erforderlich.",
+    "enterPassword": "Passwort ist erforderlich.",
+    "confirmPassword": "Passwortbestätigung ist erforderlich.",
+    "enterFirstName": "Vorname ist erforderlich.",
+    "enterLastName": "Nachname ist erforderlich.",
+    "enterPhone": "Telefonnummer ist erforderlich.",
+    "enterCompany": "Firma ist erforderlich.",
+    "enterTitle": "Titel ist erforderlich.",
+    "enterFieldName": "{{fieldName}} ist erforderlich."
+  },
+  "buttons": {
+    "account": "Mein Konto",
+    "login": "Anmelden",
+    "subscribe": "Abonnieren"
+  },
+  "dashboard": {
+    "labels": {
+      "menu": "Pelcro-Menü",
+      "name": "Name",
+      "email": "E-Mail",
+      "plan": "Tarif",
+      "description": "Beschreibung",
+      "expiry": "Ablauf",
+      "status": "Status",
+      "logout": "Abmelden",
+      "dashboard": "Dashboard",
+      "unsubscribe": "Kündigen",
+      "reactivate": "Reaktivieren",
+      "renew": "Verlängern",
+      "support": "Support",
+      "account": "Konto",
+      "subscriptions": "Abonnements",
+      "updatePaymentSource": "Aktualisieren",
+      "updateProfile": "Aktualisieren",
+      "updateAddress": "Aktualisieren",
+      "redeemGift": "Geschenk einlösen",
+      "address": "Adresse",
+      "paymentSource": "Zahlungskarte",
+      "actions": "Aktionen",
+      "expiresOn": "Läuft ab am",
+      "renewsOn": "Verlängert sich am",
+      "isSureToCancel": "Sind Sie sicher, dass Sie Ihr Abonnement kündigen möchten?"
+    },
+    "messages": {
+      "yourDashboard": "Ihr Pelcro-Dashboard"
+    },
+    "errors": {
+      "": ""
+    }
+  },
+  "select": {
+    "messages": {
+      "alreadyHaveAccount": "Haben Sie bereits ein Konto?",
+      "loginHere": "Hier anmelden",
+      "checkbox": "Aktivieren Sie dieses Kästchen, um dieses Abonnement zu verschenken"
+    },
+    "labels": {
+      "plan": {
+        "title": "Einen Tarif abonnieren",
+        "subtitle": "Wählen Sie einen der untenstehenden Tarife aus und klicken Sie auf Weiter."
+      },
+      "product": {
+        "title": "Ein Produkt abonnieren",
+        "subtitle": "Wählen Sie eines der untenstehenden Produkte aus und klicken Sie auf Weiter."
+      },
+      "selectProduct": "Produkt auswählen",
+      "selectPlan": "Tarif auswählen",
+      "startingAt": "Ab"
+    },
+    "buttons": {
+      "next": "Weiter",
+      "select": "Auswählen",
+      "back": "Zurück"
+    }
+  },
+  "confirm": {
+    "buttons": {
+      "continue": "Weiter zum Inhalt"
+    },
+    "labels": {
+      "title": "Vielen Dank für Ihre Bestellung!",
+      "subtitle": "Ihre Artikel sind in Kürze unterwegs."
+    },
+    "giftSent": "Das Geschenk wird gesendet an",
+    "successfully": "am von Ihnen angegebenen Datum."
+  }
+}

--- a/src/translations/de/dashboard.json
+++ b/src/translations/de/dashboard.json
@@ -1,0 +1,137 @@
+{
+  "labels": {
+    "menu": "Pelcro-Menü",
+    "name": "Name",
+    "email": "E-Mail",
+    "plan": "Tarif",
+    "description": "Beschreibung",
+    "expiry": "Ablauf",
+    "status": {
+      "title": "Status",
+      "active": "Aktiv",
+      "inTrial": "In Testphase",
+      "endingSoon": "Endet bald",
+      "scheduled": "Geplant",
+      "incomplete": "Unvollständig"
+    },
+    "manageMembers": "Mitglieder verwalten",
+    "shipments": "Verbleibende Lieferungen",
+    "logout": "Abmelden",
+    "dashboard": "Dashboard",
+    "unsubscribe": "Kündigen",
+    "reactivate": "Reaktivieren",
+    "renew": "Verlängern",
+    "suspend": "Aussetzen",
+    "unsuspend": "Fortsetzen",
+    "support": "Support",
+    "account": "Konto",
+    "purchases": "Käufe",
+    "subscriptions": "Abonnements",
+    "donations": "Spenden",
+    "memberships": "Mitgliedschaften",
+    "invoices": "Rechnungen",
+    "details": "Details",
+    "view": "Ansehen",
+    "paid": "Bezahlt",
+    "open": "Offen",
+    "draft": "Entwurf",
+    "scheduled": "Geplant",
+    "uncollectible": "Uneinbringlich",
+    "void": "Storniert",
+    "pastDue": "Überfällig",
+    "updatePaymentSource": "Aktualisieren",
+    "profile": "Profil",
+    "updateProfile": "Profil bearbeiten",
+    "changePassword": "Passwort ändern",
+    "editNewsletters": "Newsletter bearbeiten",
+    "myQRCode": "Mein QR-Code",
+    "shipping": "Versand",
+    "billing": "Abrechnung",
+    "edit": "Bearbeiten",
+    "gifts": "Geschenke",
+    "redeemGift": "Geschenk einlösen",
+    "address": "Adresse",
+    "addresses": "Adressen",
+    "myProfile": "Mein Profil",
+    "paymentSource": "Zahlungskarten",
+    "actions": "Aktionen",
+    "expiresOn": "Endet",
+    "until": "Bis",
+    "startsOn": "Beginnt",
+    "startDate": "Startdatum",
+    "renewsOn": "Verlängert sich",
+    "canceledOn": "Gekündigt am",
+    "recipient": "Empfänger",
+    "addPaymentSource": "Zahlungsmethode hinzufügen",
+    "setDefault": "Als Standard festlegen",
+    "addAddress": "Adresse hinzufügen",
+    "editAddress": "Adresse bearbeiten",
+    "addSubscription": "Neues Abonnement",
+    "addGift": "Neues Geschenk",
+    "default": "Standard",
+    "orders": {
+      "label": "Bestellungen",
+      "noOrders": "Sie haben noch keine Bestellungen aufgegeben",
+      "total": "Gesamt",
+      "date": "Datum",
+      "details": "Details",
+      "itemsAmount": "{{count}} Artikel",
+      "itemsAmount_plural": "{{count}} Artikel"
+    },
+    "savedItems": {
+      "label": "Gespeichert & Gefolgt",
+      "noSavedItems": "Sie haben keine gespeicherten Artikel",
+      "categories": "Kategorien",
+      "details": "Details",
+      "removeItem": "Entfernen"
+    },
+    "subCancellation": {
+      "goBack": "Zurück"
+    },
+    "donationCancellation": {
+      "goBack": "Zurück"
+    }
+  },
+  "messages": {
+    "noCard": "Sie haben keine Karte",
+    "subCancellation": {
+      "isSureToCancel": "Sind Sie sicher, dass Sie Ihr Abonnement kündigen möchten?",
+      "loading": "Ihr Abonnement wird gekündigt",
+      "success": "Abonnement wurde erfolgreich gekündigt",
+      "error": "Fehler beim Kündigen Ihres Abonnements"
+    },
+    "subReactivation": {
+      "success": "Abonnement wurde erfolgreich reaktiviert",
+      "error": "Fehler beim Reaktivieren Ihres Abonnements"
+    },
+    "subUnSuspend": {
+      "isSureToUnSuspend": "Sind Sie sicher, dass Sie Ihr Abonnement fortsetzen möchten?",
+      "loading": "Ihr Abonnement wird fortgesetzt",
+      "success": "Abonnement wurde erfolgreich fortgesetzt",
+      "error": "Fehler beim Fortsetzen Ihres Abonnements"
+    },
+    "donationCancellation": {
+      "isSureToCancel": "Sind Sie sicher, dass Sie Ihre Spende stornieren möchten?",
+      "loading": "Ihre Spende wird storniert",
+      "success": "Spende wurde erfolgreich storniert",
+      "error": "Fehler beim Stornieren Ihrer Spende"
+    },
+    "donationReactivation": {
+      "success": "Spende wurde erfolgreich reaktiviert",
+      "error": "Fehler beim Reaktivieren Ihrer Spende"
+    },
+    "donationUnSuspend": {
+      "isSureToUnSuspend": "Sind Sie sicher, dass Sie Ihre Spende fortsetzen möchten?",
+      "loading": "Ihre Spende wird fortgesetzt",
+      "success": "Spende wurde erfolgreich fortgesetzt",
+      "error": "Fehler beim Fortsetzen Ihrer Spende"
+    },
+    "paymentMethodDeletion": {
+      "isSureToDelete": "Sind Sie sicher, dass Sie diese Zahlungsmethode löschen möchten?",
+      "loading": "Ihre Zahlungsmethode wird gelöscht",
+      "success": "Zahlungsmethode wurde erfolgreich gelöscht",
+      "error": "Fehler beim Löschen Ihrer Zahlungsmethode",
+      "nonDeletable": "Diese Zahlungsmethode kann nicht gelöscht werden"
+    }
+  }
+}

--- a/src/translations/de/donation.json
+++ b/src/translations/de/donation.json
@@ -1,0 +1,30 @@
+{
+  "messages": {
+    "alreadyHaveAccount": "Haben Sie bereits ein Konto?",
+    "loginHere": "Hier anmelden",
+    "checkbox": "Aktivieren Sie dieses Kästchen, um dieses Abonnement zu verschenken"
+  },
+  "labels": {
+    "plan": {
+      "title": "Einen Tarif abonnieren",
+      "subtitle": "Wählen Sie einen der untenstehenden Tarife aus und klicken Sie auf Weiter."
+    },
+    "product": {
+      "title": "Ein Produkt abonnieren",
+      "subtitle": "Wählen Sie eines der untenstehenden Produkte aus und klicken Sie auf Weiter."
+    },
+    "selectProduct": "Produkt auswählen",
+    "selectPlan": "Tarif auswählen",
+    "startingAt": "Ab",
+    "restrictiveArticles": {
+      "subscribeTo": "Abonnieren Sie eine der folgenden Optionen, um Zugriff auf diese Seite zu erhalten",
+      "or": "Oder werfen Sie einen Blick auf einige unserer anderen Optionen unten"
+    }
+  },
+  "buttons": {
+    "signupAndDonate": "Registrieren & spenden",
+    "donate": "Spenden",
+    "select": "Auswählen",
+    "back": "Zurück"
+  }
+}

--- a/src/translations/de/login.json
+++ b/src/translations/de/login.json
@@ -1,0 +1,29 @@
+{
+  "labels": {
+    "email": "E-Mail eingeben",
+    "username": "Benutzernamen eingeben",
+    "password": "Passwort eingeben",
+    "required": "erforderlich",
+    "emailPlaceholder": "E-Mail",
+    "passwordPlaceholder": "Passwort",
+    "login": "Anmelden"
+  },
+  "messages": {
+    "loginTo": "Melden Sie sich bei Ihrem Konto an",
+    "welcome": "Willkommen zurück, melden Sie sich mit Ihrem bestehenden Konto an.",
+    "dontHaveAccount": "Haben Sie noch kein Konto?",
+    "createAccount": "Konto erstellen.",
+    "forgotPassword": "Passwort vergessen?",
+    "reset": {
+      "click": "Klicken Sie",
+      "here": "hier",
+      "toReset": ", um es zurückzusetzen."
+    },
+    "socialLogin": {
+      "label": "Oder fortfahren mit"
+    }
+  },
+  "errors": {
+    "": ""
+  }
+}

--- a/src/translations/de/messages.json
+++ b/src/translations/de/messages.json
@@ -1,0 +1,11 @@
+{
+  "youAreSafe": "Sie sind sicher - PCI-konform 128 SSL von",
+  "cancel": "Kündigen Sie Ihr Abonnement jederzeit online.",
+  "giftSent": "Das Abonnementgeschenk wurde gesendet an",
+  "successfully": "erfolgreich",
+  "entitlement": "Einige Inhalte auf dieser Seite sind mit einem oder mehreren unserer Tarife verfügbar. <1> Abonnieren </1> Sie jetzt, um vollen Zugriff auf die Seite zu erhalten.",
+  "recaptcha": "Diese Seite ist durch reCAPTCHA geschützt und es gelten die <1>Datenschutzbestimmungen</1> und <3>Nutzungsbedingungen</3> von Google.",
+  "invalidInvoice": "Ungültige Rechnungs-ID, bitte kontaktieren Sie den Support",
+  "invalidSubscription": "Ungültige Abonnement-ID, bitte kontaktieren Sie den Support",
+  "zeroTotalInvoice": "Sie können keine Rechnung über 0$ ansehen"
+}

--- a/src/translations/de/meter.json
+++ b/src/translations/de/meter.json
@@ -1,0 +1,11 @@
+{
+  "messages": {
+    "freeVisits": "Verbleibende kostenlose Besuche:",
+    "subscribeNow": "Abonnieren",
+    "alreadyHaveAccount": "Haben Sie bereits ein Konto?",
+    "loginHere": "Hier anmelden"
+  },
+  "errors": {
+    "": ""
+  }
+}

--- a/src/translations/de/newsletter.json
+++ b/src/translations/de/newsletter.json
@@ -1,0 +1,20 @@
+{
+  "title": "Geben Sie Ihre E-Mail-Adresse ein, um unseren Newsletter zu abonnieren",
+  "updateTitle": "Newsletter-Auswahl aktualisieren",
+  "subtitle": "Wir können Ihre E-Mail-Adresse für weitere Marketingkommunikation verwenden",
+  "labels": {
+    "submit": "Absenden",
+    "firstName": "Vorname",
+    "lastName": "Nachname",
+    "email": "E-Mail",
+    "postalCode": "Postleitzahl",
+    "required": "erforderlich"
+  },
+  "messages": {
+    "alreadyHaveAccount": "Haben Sie bereits ein Konto?",
+    "success": "Newsletter wurden erfolgreich aktualisiert",
+    "loginHere": "Hier anmelden.",
+    "createAnAccount": " Konto erstellen, indem Sie ",
+    "here": "hier"
+  }
+}

--- a/src/translations/de/notification.json
+++ b/src/translations/de/notification.json
@@ -1,0 +1,8 @@
+{
+  "confirm": {
+    "labels": {
+      "confirm": "Bestätigen",
+      "close": "Schließen"
+    }
+  }
+}

--- a/src/translations/de/passwordChange.json
+++ b/src/translations/de/passwordChange.json
@@ -1,0 +1,11 @@
+{
+  "title": "Ändern Sie Ihr Passwort",
+  "currentPassword": "Aktuelles Passwort",
+  "newPassword": "Neues Passwort",
+  "confirmNewPassword": "Neues Passwort bestätigen",
+  "submit": "Passwort ändern",
+  "required": "Erforderlich",
+  "passwordChanged": "Passwort wurde geändert, bitte melden Sie sich mit dem neuen Passwort an",
+  "passwordsNotMatching": "Passwörter stimmen nicht überein",
+  "weakPassword": "Ihr Passwort muss mindestens 6 Zeichen enthalten"
+}

--- a/src/translations/de/passwordForgot.json
+++ b/src/translations/de/passwordForgot.json
@@ -1,0 +1,12 @@
+{
+  "title": "Passwort vergessen?",
+  "email": "E-Mail",
+  "password": "Passwort",
+  "submit": "Absenden",
+  "required": "Erforderlich",
+  "passwordResetEmailSent": "Anweisungen zum Zurücksetzen des Passworts wurden an Ihre E-Mail-Adresse gesendet",
+  "messages": {
+    "alreadyHaveAccount": "Haben Sie bereits ein Konto?",
+    "loginHere": "hier anmelden."
+  }
+}

--- a/src/translations/de/passwordReset.json
+++ b/src/translations/de/passwordReset.json
@@ -1,0 +1,10 @@
+{
+    "title": "Setzen Sie Ihr Passwort zurück",
+    "subtitle": "Geben Sie unten ein neues Passwort ein",
+    "email": "E-Mail",
+    "password": "Passwort",
+    "confirmPassword": "Passwort bestätigen",
+    "submit": "Absenden",
+    "required": "Erforderlich",
+    "passwordUpdated": "Passwort wurde aktualisiert, bitte melden Sie sich mit dem neuen Passwort an"
+}

--- a/src/translations/de/passwordlessRequest.json
+++ b/src/translations/de/passwordlessRequest.json
@@ -1,0 +1,9 @@
+{
+  "title": "Passwortlose Anmeldung",
+  "email": "E-Mail eingeben",
+  "submit": "Absenden",
+  "required": "Erforderlich",
+  "messages": {
+    "PasswordlessLoginSuccess": "Bitte überprüfen Sie Ihre E-Mails und folgen Sie den dortigen Anweisungen"
+  }
+}

--- a/src/translations/de/payment.json
+++ b/src/translations/de/payment.json
@@ -1,0 +1,38 @@
+{
+  "labels": {
+    "cardNumber": "Kartennummer",
+    "securityCode": "Sicherheitscode",
+    "submit": "Absenden",
+    "months": {
+      "jan": "Januar",
+      "feb": "Februar",
+      "mar": "März",
+      "apr": "April",
+      "may": "Mai",
+      "jun": "Juni",
+      "jul": "Juli",
+      "aug": "August",
+      "sep": "September",
+      "oct": "Oktober",
+      "nov": "November",
+      "dec": "Dezember"
+    },
+    "checkout": {
+      "title": "Zahlungsinformationen"
+    }
+  },
+  "messages": {
+    "youAreSafe": "Sie sind sicher - PCI-konform 128 SSL von",
+    "cancel": "Kündigen Sie Ihr Abonnement jederzeit online.",
+    "giftSent": "Das Abonnementgeschenk wurde gesendet an",
+    "successfully": "erfolgreich",
+    "sourceCreated": "Zahlungsinformationen wurden hinzugefügt",
+    "sourceUpdated": "Ihre Zahlungsinformationen wurden aktualisiert",
+    "cardAuthFailed": "Wir können Ihre Zahlungsmethode nicht authentifizieren. Bitte wählen Sie eine andere Zahlungsmethode und versuchen Sie es erneut.",
+    "cardAuthNotSupported": "Die Aktualisierung Ihrer Zahlungsmethode auf eine, die eine Authentifizierung erfordert, ist derzeit nicht möglich. Bitte verwenden Sie eine andere Zahlungsmethode oder wenden Sie sich an den Kundendienst.",
+    "tryAgainFromInvoice": "Wir konnten Ihre Zahlung nicht authentifizieren, Ihr Abonnement wurde jedoch erstellt. Bitte versuchen Sie, die Rechnung mit einer anderen Zahlungsmethode aus dem Dashboard zu bezahlen."
+  },
+  "errors": {
+    "": ""
+  }
+}

--- a/src/translations/de/paymentMethod.json
+++ b/src/translations/de/paymentMethod.json
@@ -1,0 +1,40 @@
+{
+  "update": {
+    "title": "Aktualisieren Sie Ihre Zahlungsinformationen",
+    "subtitle": "Geben Sie die untenstehenden Felder ein, um Ihre Kreditkarteninformationen zu aktualisieren",
+    "selectSubtitle": "Wählen Sie eine Zahlungsmethode zum Aktualisieren aus",
+    "required": "Erforderlich",
+    "success": "Ihre Zahlungsinformationen wurden aktualisiert",
+    "secure": "Sie sind sicher - PCI-konform 128 SSL von"
+  },
+  "select": {
+    "title": "Zahlungsmethode auswählen",
+    "subtitle": "Wählen Sie eine Ihrer gespeicherten Methoden aus oder bezahlen Sie mit einer neuen",
+    "expires": "Läuft ab",
+    "buttons": {
+      "addPaymentMethod": "Mit einer anderen Zahlungsmethode bezahlen",
+      "selectPaymentMethod": "Weiter",
+      "changePaymentMethod": "Ändern"
+    }
+  },
+  "delete": {
+    "title": "Zahlungsmethode löschen",
+    "subtitle": "Sind Sie sicher, dass Sie die ausgewählte Zahlungsmethode löschen möchten?",
+    "details": "Details zur Zahlungsmethode",
+    "message": "Diese Aktion ist unwiderruflich und entfernt die Zahlungsmethode dauerhaft aus dem System. Bitte stellen Sie sicher, dass keine ausstehenden Transaktionen oder Abonnements mit dieser Zahlungsmethode verknüpft sind.",
+    "buttons": {
+      "delete": "Zahlungsmethode löschen",
+      "back": "Zurück"
+    },
+    "options": {
+      "select": "Wählen Sie eine Zahlungsmethode als Standard aus",
+      "add": "Eine neue Zahlungsmethode hinzufügen"
+    },
+    "paymentMethodReplaced": "Zahlungsmethode erfolgreich gelöscht und ersetzt",
+    "deletedSuccessfully": "Zahlungsmethode erfolgreich gelöscht"
+  },
+  "create": {
+    "title": "Neue Zahlungsmethode hinzufügen",
+    "subtitle": "Geben Sie die untenstehenden Felder ein, um Ihre Kreditkarteninformationen hinzuzufügen"
+  }
+}

--- a/src/translations/de/register.json
+++ b/src/translations/de/register.json
@@ -1,0 +1,90 @@
+{
+  "title": "Konto erstellen",
+  "subtitle": "Geben Sie unten Ihre E-Mail-Adresse und Ihr Passwort ein",
+  "labels": {
+    "signUpFacebook": "Mit Facebook registrieren",
+    "signUpGoogle": "Mit Google registrieren",
+    "signUpEmail": "Mit E-Mail registrieren",
+    "password": "Passwort",
+    "email": "E-Mail",
+    "passwordPlaceholder": "Passwort erstellen",
+    "emailPlaceholder": "E-Mail eingeben",
+    "required": "erforderlich",
+    "firstName": "Vorname",
+    "lastName": "Nachname",
+    "phone": "Telefon",
+    "company": "Firma",
+    "title": "Titel"
+  },
+  "messages": {
+    "alreadyHaveAccount": "Haben Sie bereits ein Konto?",
+    "createAccount": "Konto erstellen",
+    "loginHere": "hier anmelden. ",
+    "selectPlan": "Einen anderen Tarif auswählen ",
+    "here": "hier",
+    "iAgree": {
+      "iAgree": "Ich stimme den",
+      "terms": "Nutzungsbedingungen",
+      "and": "und",
+      "privacy": "Datenschutzbestimmungen zu."
+    },
+    "preferDisable": {
+      "click": "Klicken Sie",
+      "here": "hier",
+      "ifPrefer": ", wenn Sie Ihren Werbeblocker deaktivieren möchten."
+    },
+    "socialLogin": {
+      "label": "Oder fortfahren mit"
+    }
+  },
+  "errors": {
+    "": ""
+  },
+  "gift": {
+    "titles": {
+      "firstTitle": "Geben Sie unten die Informationen des Empfängers ein"
+    },
+    "labels": {
+      "firstName": "Vorname",
+      "lastName": "Nachname",
+      "email": "E-Mail",
+      "startDate": "Geschenkdatum",
+      "giftMessage": "Geschenknachricht ({{count}} Zeichen verbleibend)",
+      "required": "erforderlich",
+      "firstNamePlaceholder": "Vorname",
+      "lastNamePlaceholder": "Nachname",
+      "emailPlaceholder": "E-Mail-Adresse"
+    },
+    "buttons": {
+      "gift": "verschenken"
+    },
+    "messages": {
+      "enterEmail": "Bitte geben Sie die E-Mail-Adresse des Geschenkempfängers ein.",
+      "invalidDate": "Das Geschenkdatum muss zwischen heute und einem Jahr ab heute liegen.",
+      "giftDateInfo": "Der Empfänger erhält eine Geschenk-E-Mail-Benachrichtigung mit Ihrer Nachricht an dem von Ihnen ausgewählten Datum, um das Geschenk einzulösen.",
+      "giftMessageInfo": "Hinterlassen Sie dem Empfänger eine Nachricht und vergessen Sie nicht, Ihren Namen zu unterschreiben."
+    }
+  },
+  "redeem": {
+    "titles": {
+      "firstTitle": "Lösen Sie Ihr Geschenk ein",
+      "secondTitle": "Geben Sie unten den Geschenkcode ein"
+    },
+    "labels": {
+      "code": "Geschenkcode eingeben",
+      "codePlaceholder": "Geschenkcode",
+      "required": "erforderlich"
+    },
+    "buttons": {
+      "redeem": "Geschenk einlösen"
+    },
+    "footer": {
+      "click": "Klicken Sie",
+      "here": "hier",
+      "toAdd": ", um eine Adresse hinzuzufügen"
+    },
+    "messages": {
+      "enterGiftCode": "Bitte geben Sie einen Geschenkcode ein."
+    }
+  }
+}

--- a/src/translations/de/select.json
+++ b/src/translations/de/select.json
@@ -1,0 +1,29 @@
+{
+  "messages": {
+    "alreadyHaveAccount": "Haben Sie bereits ein Konto?",
+    "loginHere": "Hier anmelden",
+    "checkbox": "Aktivieren Sie dieses Kästchen, um dieses Abonnement zu verschenken"
+  },
+  "labels": {
+    "plan": {
+      "title": "Einen Tarif abonnieren",
+      "subtitle": "Wählen Sie einen der untenstehenden Tarife aus und klicken Sie auf Weiter."
+    },
+    "product": {
+      "title": "Ein Produkt abonnieren",
+      "subtitle": "Wählen Sie eines der untenstehenden Produkte aus und klicken Sie auf Weiter."
+    },
+    "selectProduct": "Produkt auswählen",
+    "selectPlan": "Tarif auswählen",
+    "startingAt": "Ab",
+    "restrictiveArticles": {
+      "subscribeTo": "Abonnieren Sie eine der folgenden Optionen, um Zugriff auf diese Seite zu erhalten",
+      "or": "Oder werfen Sie einen Blick auf einige unserer anderen Optionen unten"
+    }
+  },
+  "buttons": {
+    "next": "Weiter",
+    "select": "Auswählen",
+    "back": "Zurück"
+  }
+}

--- a/src/translations/de/shop.json
+++ b/src/translations/de/shop.json
@@ -1,0 +1,21 @@
+{
+  "buttons": {
+    "select": "Auswählen",
+    "added": "In den Warenkorb gelegt",
+    "purchase": "Kaufen",
+    "continue": "Weiter"
+  },
+  "messages": {
+    "orderConfirmed": {
+      "title": "Bestellung bestätigt!",
+      "body": "Ihre Bestellung wurde bestätigt und wird in den nächsten Tagen versandt. Sie erhalten in Kürze eine E-Mail-Bestätigung dieser Bestellung."
+    },
+    "haveQuestions": "Wenn Sie Fragen haben, zögern Sie nicht, uns zu kontaktieren!",
+    "multipleCurrencies": "Ihr Warenkorb enthält derzeit Artikel, die in verschiedenen Währungen verfügbar sind. Um mit dem Bezahlvorgang fortzufahren, stellen Sie bitte sicher, dass alle Artikel die gleiche Währung haben.",
+    "currencyMismatch": "Die ausgewählten Artikel stimmen nicht mit Ihrer aktuellen Standardwährung ({{currency}}) überein. Bitte wählen Sie nur Artikel aus, die dieser Währung entsprechen."
+  },
+  "labels": {
+    "summary": "Bestellübersicht",
+    "total": "Gesamt"
+  }
+}

--- a/src/translations/de/subscriptionCancel.json
+++ b/src/translations/de/subscriptionCancel.json
@@ -1,0 +1,25 @@
+{
+  "labels": {
+    "title": "Abonnement kündigen",
+    "cancelReason": "Kündigungsgrund",
+    "endOn": "Beenden am",
+    "endImmediately": "Sofort beenden",
+    "cancel": "Kündigen",
+    "subCancellation": {
+      "goBack": "Zurück"
+    }
+  },
+  "messages": {
+    "subscriptionEnd": "Dieses Abonnement läuft am folgenden Datum ab",
+    "cancelWhen": "Wann möchten Sie kündigen?",
+    "cancelNow": "Abonnement jetzt kündigen",
+    "cancelLater": "Zum Ende des Zeitraums kündigen",
+    "subCancellation": {
+      "isSureToCancelNow": "Sind Sie sicher, dass Sie Ihr Abonnement sofort kündigen möchten?",
+      "isSureToCancel": "Sind Sie sicher, dass Sie Ihr Abonnement kündigen möchten?",
+      "loading": "Ihr Abonnement wird gekündigt",
+      "success": "Abonnement wurde erfolgreich gekündigt",
+      "error": "Fehler beim Kündigen Ihres Abonnements"
+    }
+  }
+}

--- a/src/translations/de/subscriptionManageMembers.json
+++ b/src/translations/de/subscriptionManageMembers.json
@@ -1,0 +1,13 @@
+{
+  "labels": {
+    "inviteMembers": "Mitglieder einladen",
+    "listOfMembers": "Mitgliederliste",
+    "invite": "Einladen",
+    "remove": "Entfernen",
+    "emails": "E-Mail-Adressen eingeben",
+    "status": "Status",
+    "actions": "Aktionen",
+    "email": "E-Mail",
+    "listNote": "Kommagetrennte Liste, z. B."
+  }
+}

--- a/src/translations/de/subscriptionSuspend.json
+++ b/src/translations/de/subscriptionSuspend.json
@@ -1,0 +1,21 @@
+{
+  "labels": {
+    "title": "Abonnement aussetzen",
+    "suspensionDate": "Aussetzungsdatum",
+    "subCancellation": {
+      "goBack": "Zurück"
+    }
+  },
+  "messages": {
+    "suspensionEnd": "Die Aussetzung läuft am folgenden Datum ab",
+    "suspendNow": "Abonnement jetzt aussetzen",
+    "suspendLater": "Zum Ende des Zeitraums aussetzen",
+    "subCancellation": {
+      "isSureToSuspendNow": "Sind Sie sicher, dass Sie Ihr Abonnement sofort aussetzen möchten?",
+      "isSureToSuspend": "Sind Sie sicher, dass Sie Ihr Abonnement aussetzen möchten?",
+      "loading": "Ihr Abonnement wird ausgesetzt",
+      "success": "Abonnement wurde erfolgreich ausgesetzt",
+      "error": "Fehler beim Aussetzen Ihres Abonnements"
+    }
+  }
+}

--- a/src/translations/de/success.json
+++ b/src/translations/de/success.json
@@ -1,0 +1,30 @@
+{
+  "labels": {
+    "continue": "Weiter zum Inhalt"
+  },
+  "messages": {
+    "yourFreeTrial": "Abonnement erfolgreich!",
+    "youHaveAccess": "Wir hoffen, Sie genießen das Abonnement. Bitte kontaktieren Sie uns, wenn Sie Fragen oder Bedenken haben.",
+    "clickToLearn": {
+      "click": "Klicken Sie",
+      "here": "hier",
+      "toLearn": ", um mehr zu erfahren, oder kontaktieren Sie uns unter",
+      "forQuestion": "bei Fragen."
+    },
+    "giftCreate": {
+      "title": "Ihr Geschenk wurde gesendet",
+      "content": "Ihr Empfänger erhält in Kürze eine E-Mail mit Anweisungen zum Einlösen seines Geschenks."
+    },
+    "giftRedeem": {
+      "title": "Herzlichen Glückwunsch",
+      "content": "Sie haben Ihr Geschenkabonnement erfolgreich eingelöst. Viel Spaß!"
+    },
+    "invoicePayment": {
+      "title": "Rechnung erfolgreich bezahlt",
+      "content": "Bitte kontaktieren Sie uns, wenn Sie Fragen oder Bedenken haben."
+    }
+  },
+  "errors": {
+    "": ""
+  }
+}

--- a/src/translations/de/userEdit.json
+++ b/src/translations/de/userEdit.json
@@ -1,0 +1,28 @@
+{
+  "labels": {
+    "title": "Möchten Sie Ihr Profil aktualisieren?",
+    "subtitle": "Geben Sie unten Ihre Informationen ein, um Ihr Profil zu aktualisieren",
+    "email": "E-Mail",
+    "firstName": "Vorname",
+    "lastName": "Nachname",
+    "username": "Benutzername",
+    "displayname": "Anzeigename",
+    "phone": "Telefon",
+    "submit": "Absenden",
+    "required": "Erforderlich",
+    "cropperTitle": "Profilbild aktualisieren",
+    "cropperSubtitle": "Laden Sie ein Foto hoch und passen Sie es nach Ihren Wünschen an",
+    "save": "Foto hochladen",
+    "selectImage": "Neues Foto hochladen",
+    "removeImage": "Aktuelles Foto entfernen",
+    "zoom": "Zoom",
+    "tin": "Steueridentifikationsnummer",
+    "company": "Firma",
+    "userTitle": "Titel"
+  },
+  "messages": {
+    "userUpdated": "Vielen Dank! Ihr Profil wurde erfolgreich aktualisiert.",
+    "pictureRemoved": "Ihr Profilbild wurde erfolgreich entfernt.",
+    "pictureUpdated": "Ihr Profilbild wurde erfolgreich aktualisiert."
+  }
+}

--- a/src/translations/de/verifyEmail.json
+++ b/src/translations/de/verifyEmail.json
@@ -1,0 +1,11 @@
+{
+  "labels": {
+    "title": "E-Mail bestätigen",
+    "instructions": "Sie sind auf dem Weg!\nLassen Sie uns Ihre E-Mail-Adresse bestätigen.\nKlicken Sie auf den Bestätigungslink, den wir an Ihre E-Mail-Adresse gesendet haben:",
+    "resend": "E-Mail erneut senden"
+  },
+  "messages": {
+    "resent": "Erfolgreich erneut gesendet",
+    "success": "E-Mail erfolgreich bestätigt!"
+  }
+}

--- a/src/translations/de/verifyLinkToken.json
+++ b/src/translations/de/verifyLinkToken.json
@@ -1,0 +1,11 @@
+{
+  "labels": {
+    "title": "Passwortlosen Link bestätigen",
+    "instructions": "Sie sind auf dem Weg!\nLassen Sie uns Ihre E-Mail-Adresse bestätigen.\nKlicken Sie auf den Bestätigungslink, den wir an Ihre E-Mail-Adresse gesendet haben:",
+    "resend": "E-Mail erneut senden"
+  },
+  "messages": {
+    "resent": "Erfolgreich erneut gesendet",
+    "success": "Sie haben sich erfolgreich angemeldet"
+  }
+}


### PR DESCRIPTION
## Summary
Adds German as the fifth locale to `@pelcro/react-pelcro-js` (alongside en, fr, ko, es).

## Changes
- **Create** `src/translations/de/` — all namespace files, keys mirroring `en/` exactly (source of truth)
- **Modify** `src/i18n.js` — add de imports + `de:` resources block (follows es/ pattern)

## Key details
- Formal "Sie" register throughout
- All interpolation tokens preserved verbatim (`{{count}}`, `{{name}}`, etc.)
- Both plural key pairs preserved (`interval`/`interval_plural`, `itemsAmount`/`itemsAmount_plural`)
- Key parity validated — de/ matches en/ key count
- No change to any React component, utils, SDK, or client UIs
- Minor npm version bump required before client rollout

## Activation
Set `<html lang="de">` or `site.default_locale = 'de'` or `'de_DE'`.
Variants `de-AT`, `de-CH` also resolve to base `de` via `getLanguageWithoutRegion()`.

## Linked Task
Asana: https://app.asana.com/1/742417627358732/project/1201176291286264/task/1214878453063042