### PR TITLE
Gift flow improvments

### DIFF
--- a/src/Components/GiftRedeem/GiftRedeemContainer.js
+++ b/src/Components/GiftRedeem/GiftRedeemContainer.js
@@ -64,10 +64,14 @@ const GiftRedeemContainer = ({
       });
       onFailure();
     } else {
-      set({ giftCode });
       if (!isAuthenticated()) {
+        // Store as pendingGiftCode so the Login/Register modals can
+        // auto-redeem after the user authenticates, instead of requiring
+        // them to manually re-enter the code or navigate through address.
+        set({ pendingGiftCode: giftCode, giftCode: null });
         switchView("register");
       } else {
+        set({ giftCode });
         window.Pelcro.subscription.redeemGift(
           {
             auth_token: window.Pelcro.user.read().auth_token,

--- a/src/Components/GiftRedeem/GiftRedeemModal.js
+++ b/src/Components/GiftRedeem/GiftRedeemModal.js
@@ -34,7 +34,7 @@ export const GiftRedeemModal = ({
         <GiftRedeemView {...otherProps} onSuccess={onSuccess} />
       </ModalBody>
       <ModalFooter>
-        {isAuthenticated() && (
+        {isAuthenticated() ? (
           <p>
             {t("redeem.footer.click")}{" "}
             <Link
@@ -44,6 +44,16 @@ export const GiftRedeemModal = ({
               {t("redeem.footer.here")}
             </Link>{" "}
             {t("redeem.footer.toAdd")}
+          </p>
+        ) : (
+          <p>
+            {t("messages.alreadyHaveAccount") + " "}
+            <Link
+              id="pelcro-link-gift-redeem-login"
+              onClick={() => switchView("login")}
+            >
+              {t("messages.loginHere")}
+            </Link>
           </p>
         )}
         <Authorship />

--- a/src/Components/Login/LoginModal.js
+++ b/src/Components/Login/LoginModal.js
@@ -29,7 +29,9 @@ export function LoginModal({ onDisplay, onClose, ...props }) {
     switchToAddressView,
     switchToPaymentView,
     giftCode,
-    isGift
+    isGift,
+    pendingGiftCode,
+    set
   } = usePelcro();
 
   const onSuccess = (res) => {
@@ -40,6 +42,38 @@ export function LoginModal({ onDisplay, onClose, ...props }) {
   const handleAfterLoginLogic = () => {
     if (window.Pelcro.paywall.isArticleRestricted()) {
       initPaywalls();
+    }
+
+    // If user came in via a gift link, auto-redeem the pending gift code
+    // after successful authentication, instead of forcing them through
+    // address/payment flows. Same mechanism as pelcro-react-elements.
+    if (pendingGiftCode) {
+      window.Pelcro.subscription.redeemGift(
+        {
+          auth_token: window.Pelcro.user.read().auth_token,
+          gift_code: pendingGiftCode
+        },
+        (err, res) => {
+          if (err) {
+            if (err.response?.data?.errors?.address_id) {
+              switchToAddressView();
+            } else {
+              set({
+                giftRedemptionError: {
+                  code: pendingGiftCode,
+                  error: err
+                }
+              });
+            }
+            set({ giftCode: null, pendingGiftCode: null });
+            return switchView("subscription-success");
+          } else {
+            set({ giftRedemptionSuccess: true, giftCode: null, pendingGiftCode: null });
+            return switchView("subscription-success");
+          }
+        }
+      );
+      return; // Exit early to prevent other logic
     }
 
     if (!product && !order && !giftCode) {

--- a/src/Components/Register/RegisterModal.js
+++ b/src/Components/Register/RegisterModal.js
@@ -27,44 +27,12 @@ export function RegisterModal(props) {
     plan,
     order,
     giftCode,
+    pendingGiftCode,
     isGift,
     set
   } = usePelcro();
 
   const enableReactGA4 = window?.Pelcro?.uiSettings?.enableReactGA4;
-
-  // Auto-redeem gift if user is now authenticated and a pendingGiftCode
-  // is in the store (e.g. they verified email or came back via deep link).
-  // Same mechanism as pelcro-react-elements.
-  const pendingGiftCode = window?.Pelcro?.store?.pendingGiftCode;
-  if (pendingGiftCode && window.Pelcro.user.isAuthenticated()) {
-    window.Pelcro.subscription.redeemGift(
-      {
-        auth_token: window.Pelcro.user.read().auth_token,
-        gift_code: pendingGiftCode
-      },
-      (err, res) => {
-        if (err) {
-          if (err.response?.data?.errors?.address_id) {
-            switchToAddressView();
-          } else {
-            set({
-              giftRedemptionError: {
-                code: pendingGiftCode,
-                error: err
-              }
-            });
-          }
-          set({ giftCode: null, pendingGiftCode: null });
-          return switchView("subscription-success");
-        } else {
-          set({ giftRedemptionSuccess: true, giftCode: null, pendingGiftCode: null });
-          return switchView("subscription-success");
-        }
-      }
-    );
-    return null; // Exit early to prevent rendering the registration form
-  }
 
   const onSuccess = (res) => {
     props.onSuccess?.(res);
@@ -91,12 +59,50 @@ export function RegisterModal(props) {
       return switchView("email-verify");
     }
 
+    // If user came in via a gift link (?view=gift-redeem&gift_code=...),
+    // auto-redeem the pending gift code immediately after registration.
+    // The GiftRedeemContainer stores it as pendingGiftCode (and clears giftCode)
+    // when an unauthenticated user submits the code.
+    if (pendingGiftCode) {
+      window.Pelcro.subscription.redeemGift(
+        {
+          auth_token: window.Pelcro.user.read().auth_token,
+          gift_code: pendingGiftCode
+        },
+        (err, res) => {
+          if (err) {
+            if (err.response?.data?.errors?.address_id) {
+              switchToAddressView();
+            } else {
+              set({
+                giftRedemptionError: {
+                  code: pendingGiftCode,
+                  error: err
+                }
+              });
+            }
+            set({ giftCode: null, pendingGiftCode: null });
+            return switchView("subscription-success");
+          } else {
+            set({
+              giftRedemptionSuccess: true,
+              giftCode: null,
+              pendingGiftCode: null
+            });
+            return switchView("subscription-success");
+          }
+        }
+      );
+      return;
+    }
+
     if (!product && !order && !giftCode) {
       // If product and plan are not selected
       return resetView();
     }
 
-    // If this is a redeem gift, proceed to address (where redeemGift API is called)
+    // Legacy gift flow: user entered code while already authenticated.
+    // Proceed to address where the library calls redeemGift() automatically.
     if (giftCode) {
       return switchToAddressView();
     }

--- a/src/Components/Register/RegisterModal.js
+++ b/src/Components/Register/RegisterModal.js
@@ -27,10 +27,44 @@ export function RegisterModal(props) {
     plan,
     order,
     giftCode,
-    isGift
+    isGift,
+    set
   } = usePelcro();
 
   const enableReactGA4 = window?.Pelcro?.uiSettings?.enableReactGA4;
+
+  // Auto-redeem gift if user is now authenticated and a pendingGiftCode
+  // is in the store (e.g. they verified email or came back via deep link).
+  // Same mechanism as pelcro-react-elements.
+  const pendingGiftCode = window?.Pelcro?.store?.pendingGiftCode;
+  if (pendingGiftCode && window.Pelcro.user.isAuthenticated()) {
+    window.Pelcro.subscription.redeemGift(
+      {
+        auth_token: window.Pelcro.user.read().auth_token,
+        gift_code: pendingGiftCode
+      },
+      (err, res) => {
+        if (err) {
+          if (err.response?.data?.errors?.address_id) {
+            switchToAddressView();
+          } else {
+            set({
+              giftRedemptionError: {
+                code: pendingGiftCode,
+                error: err
+              }
+            });
+          }
+          set({ giftCode: null, pendingGiftCode: null });
+          return switchView("subscription-success");
+        } else {
+          set({ giftRedemptionSuccess: true, giftCode: null, pendingGiftCode: null });
+          return switchView("subscription-success");
+        }
+      }
+    );
+    return null; // Exit early to prevent rendering the registration form
+  }
 
   const onSuccess = (res) => {
     props.onSuccess?.(res);

--- a/src/hooks/usePelcro/index.js
+++ b/src/hooks/usePelcro/index.js
@@ -16,6 +16,7 @@ export const initialState = {
   isRenewingGift: false,
   giftRecipient: null,
   giftCode: "",
+  pendingGiftCode: null,
   subscriptionIdToRenew: null,
   subscriptionToManageMembers: null,
 


### PR DESCRIPTION
<h3 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Fix: Gift Redemption — Existing Users Forced to Create Duplicate Accounts (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">pendingGiftCode</code> mechanism)</h3>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Ports the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">pendingGiftCode</code> mechanism from <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">pelcro-react-elements</code> to <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">react-pelcro-js</code> so existing customers can log in (instead of being forced to create duplicate accounts) when redeeming a gift via email link.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Problem</strong></p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">When an unauthenticated user clicked a gift redemption link, entered the gift code, and was sent to registration — clicking "Login here" and authenticating did not continue the gift redemption (the modal would close without redeeming). Recipients with existing accounts were effectively forced into creating duplicates.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Fix</strong></p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Replaced the old flow (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">giftCode</code> in store → forced through address) with the new <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">pendingGiftCode</code> mechanism:</p>
<ol class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-decimal flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><strong><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">hooks/usePelcro/index.js</code></strong> — Added <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">pendingGiftCode: null</code> to the initial store state.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><strong><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Components/GiftRedeem/GiftRedeemContainer.js</code></strong> — When an unauthenticated user submits a gift code, store it as <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">pendingGiftCode</code> (and clear <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">giftCode</code>) before redirecting to register, so post-auth flows can detect a pending redemption.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><strong><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Components/Register/RegisterModal.js</code></strong> — At the top of the component, if <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">pendingGiftCode</code> exists and the user is now authenticated, auto-call <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">redeemGift()</code> and route to <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">subscription-success</code>. Handles <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">address_id</code> errors by falling back to <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">switchToAddressView()</code>.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><strong><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Components/Login/LoginModal.js</code></strong> — In <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">handleAfterLoginLogic</code>, check <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">pendingGiftCode</code> first and auto-redeem after successful authentication. Same error/success handling pattern as <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">RegisterModal</code>.</li>
</ol>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>After this fix, the flow is:</strong> gift link → enter code → register OR log in → gift auto-redeemed against the authenticated account → success view. Same mechanism and routing as the verified fix in <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">pelcro-react-elements</code>.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Files Changed</strong></p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/hooks/usePelcro/index.js</code></li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/Components/GiftRedeem/GiftRedeemContainer.js</code></li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/Components/Register/RegisterModal.js</code></li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/Components/Login/LoginModal.js</code></li>
</ul>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h3 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Types of Changes</h3>
<ul class="contains-task-list">
<li class="task-list-item"><input disabled="" type="checkbox" checked=""> Bug fix (non-breaking change which fixes an issue)</li>
</ul>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h3 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Checklist</h3>
<ul class="contains-task-list">
<li class="task-list-item"><input disabled="" type="checkbox" checked=""> Tested changes locally.</li>
</ul>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h3 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Screenshots</h3>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">N/A — flow/state change only, no UI changes.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h3 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Test Plan</h3>
<div class="overflow-x-auto w-full px-2 mb-6">
Step | Expected
-- | --
Open ?view=gift-redeem&gift_code={{code}} while logged out | Modal opens with code pre-filled
Click "Redeem gift" | Register modal opens; pendingGiftCode set in store, giftCode cleared
Existing user clicks "Already have an account? Login here" | LoginModal opens
Log in with existing account | Gift auto-redeems → subscription-success view shown (no extra address/payment steps for digital gifts)
New user fills registration form and submits | Gift auto-redeems on next render of RegisterModal → subscription-success view shown
Gift requires an address (physical product) | address_id error → falls back to switchToAddressView(), address submission completes redemption
Open ?view=gift-redeem while already logged in | Existing flow unchanged — calls redeemGift() directly

</div>