### PR TITLE
feat: add set as default

### DIFF
--- a/src/Components/PaymentMethod/PaymentMethodContainer.js
+++ b/src/Components/PaymentMethod/PaymentMethodContainer.js
@@ -1490,7 +1490,8 @@ const formatPaymentAmount = (
          {
            auth_token: window.Pelcro.user.read().auth_token,
            token: braintreeNonce,
-           gateway: "braintree"
+           gateway: "braintree",
+           is_default: state.isDefault
          },
          (err, res) => {
            dispatch({ type: DISABLE_SUBMIT, payload: false });
@@ -1505,7 +1506,7 @@ const formatPaymentAmount = (
                }
              });
            }
- 
+
            dispatch({
              type: SHOW_ALERT,
              payload: {
@@ -1517,7 +1518,7 @@ const formatPaymentAmount = (
          }
        );
      }
- 
+
      function replaceBraintreeCard() {
        const { id: paymentMethodId } = paymentMethodToDelete;
  
@@ -1793,7 +1794,8 @@ const formatPaymentAmount = (
         {
           auth_token: window.Pelcro.user.read().auth_token,
           token: paymentRequest,
-          gateway: "vantiv"
+          gateway: "vantiv",
+          is_default: state.isDefault
         },
         (err, res) => {
           dispatch({ type: DISABLE_SUBMIT, payload: false });
@@ -2910,7 +2912,8 @@ const formatPaymentAmount = (
         window.Pelcro.paymentMethods.create(
           {
             auth_token: window.Pelcro.user.read().auth_token,
-            token: source.id
+            token: source.id,
+            is_default: state.isDefault
           },
           (err, res) => {
             if (err) {

--- a/src/Components/PaymentMethod/PaymentMethodView.js
+++ b/src/Components/PaymentMethod/PaymentMethodView.js
@@ -29,6 +29,7 @@ import {
 } from "../../utils/utils";
 import { ApplePayButton } from "../ApplePayButton/ApplePayButton";
 import { PaymentMethodUpdateSetDefault } from "../PaymentMethodUpdate/PaymentMethodUpdateSetDefault";
+import { PaymentMethodCreateSetDefault } from "../PaymentMethodCreate/PaymentMethodCreateSetDefault";
 
 /**
  *
@@ -190,6 +191,15 @@ export function PaymentMethodView({
                   label={t("labels.isDefault")}
                 />
               )}
+
+              {type === "createPaymentSource" &&
+                window.Pelcro?.uiSettings
+                  ?.showSetAsDefaultOnCreate === true && (
+                  <PaymentMethodCreateSetDefault
+                    id="pelcro-input-is-default"
+                    label={t("labels.isDefault")}
+                  />
+                )}
 
               {/* Payment buttons section */}
               <div className="plc-grid plc-mt-4 plc-gap-y-2">

--- a/src/Components/PaymentMethodCreate/PaymentMethodCreateSetDefault.js
+++ b/src/Components/PaymentMethodCreate/PaymentMethodCreateSetDefault.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useContext } from "react";
+import { Checkbox } from "../../SubComponents/Checkbox";
+import {
+  HANDLE_CHECKBOX_CHANGE,
+  SET_IS_DEFAULT_PAYMENT_METHOD
+} from "../../utils/action-types";
+import { store } from "../PaymentMethod/PaymentMethodContainer";
+
+/**
+ * Renders a "Set as default" checkbox in the Add Payment Method modal.
+ *
+ * Visibility is gated by `window.Pelcro.uiSettings.showSetAsDefaultOnCreate`
+ * at the call site (PaymentMethodView). Initial checked state mirrors
+ * `window.Pelcro.uiSettings.defaultCheckedSetAsDefaultOnCreate`.
+ *
+ * Both flags default to `false` so no behaviour change for tenants that
+ * have not explicitly opted in.
+ */
+export function PaymentMethodCreateSetDefault(props) {
+  const {
+    dispatch,
+    state: { isDefault }
+  } = useContext(store);
+
+  useEffect(() => {
+    const defaultChecked = Boolean(
+      window.Pelcro?.uiSettings?.defaultCheckedSetAsDefaultOnCreate
+    );
+
+    if (defaultChecked) {
+      dispatch({
+        type: SET_IS_DEFAULT_PAYMENT_METHOD,
+        payload: { isDefault: true }
+      });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleCheckboxChange = (e) => {
+    dispatch({
+      type: HANDLE_CHECKBOX_CHANGE,
+      payload: { isDefault: e.target.checked }
+    });
+  };
+
+  return (
+    <Checkbox
+      onChange={(e) => handleCheckboxChange(e)}
+      id={props.id}
+      checked={isDefault}
+    >
+      {props.label}
+    </Checkbox>
+  );
+}

--- a/src/Components/PaymentMethodCreate/__tests__/PaymentMethodCreateSetDefault.test.js
+++ b/src/Components/PaymentMethodCreate/__tests__/PaymentMethodCreateSetDefault.test.js
@@ -1,0 +1,109 @@
+/* eslint-disable import/no-unused-modules */
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+
+// Mock the PaymentMethodContainer module BEFORE importing the component
+// under test, so we don't pull in the (very large) container and its
+// SVG/asset imports — we only need its `store` context for the component.
+jest.mock("../../PaymentMethod/PaymentMethodContainer", () => {
+  const ReactLocal = require("react");
+  return {
+    __esModule: true,
+    store: ReactLocal.createContext({
+      state: { isDefault: false },
+      dispatch: () => {}
+    })
+  };
+});
+
+// eslint-disable-next-line import/first
+import { PaymentMethodCreateSetDefault } from "../PaymentMethodCreateSetDefault";
+// eslint-disable-next-line import/first
+import { store } from "../../PaymentMethod/PaymentMethodContainer";
+// eslint-disable-next-line import/first
+import {
+  HANDLE_CHECKBOX_CHANGE,
+  SET_IS_DEFAULT_PAYMENT_METHOD
+} from "../../../utils/action-types";
+
+const renderWithStore = ({
+  isDefault = false,
+  dispatch = jest.fn()
+} = {}) => {
+  const value = {
+    state: { isDefault },
+    dispatch
+  };
+
+  const utils = render(
+    <store.Provider value={value}>
+      <PaymentMethodCreateSetDefault
+        id="pelcro-input-is-default"
+        label="Set as default"
+      />
+    </store.Provider>
+  );
+
+  return { ...utils, dispatch };
+};
+
+describe("PaymentMethodCreateSetDefault", () => {
+  beforeEach(() => {
+    // Reset uiSettings between tests so each case is isolated.
+    // Default both flags to absent — opt-in is per-tenant.
+    window.Pelcro = window.Pelcro || {};
+    window.Pelcro.uiSettings = {};
+  });
+
+  test("renders a checkbox input with the provided label", () => {
+    renderWithStore();
+    const checkbox = screen.getByLabelText("Set as default");
+    expect(checkbox).not.toBeNull();
+    expect(checkbox.tagName).toBe("INPUT");
+    expect(checkbox.type).toBe("checkbox");
+  });
+
+  test("checkbox is unchecked when defaultCheckedSetAsDefaultOnCreate is absent", () => {
+    renderWithStore({ isDefault: false });
+    const checkbox = screen.getByLabelText("Set as default");
+    expect(checkbox.checked).toBe(false);
+  });
+
+  test("checkbox is unchecked when defaultCheckedSetAsDefaultOnCreate is explicitly false", () => {
+    window.Pelcro.uiSettings.defaultCheckedSetAsDefaultOnCreate = false;
+    renderWithStore({ isDefault: false });
+    const checkbox = screen.getByLabelText("Set as default");
+    expect(checkbox.checked).toBe(false);
+  });
+
+  test("dispatches SET_IS_DEFAULT_PAYMENT_METHOD on mount when defaultCheckedSetAsDefaultOnCreate is true", () => {
+    window.Pelcro.uiSettings.defaultCheckedSetAsDefaultOnCreate = true;
+    const { dispatch } = renderWithStore({ isDefault: false });
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: SET_IS_DEFAULT_PAYMENT_METHOD,
+      payload: { isDefault: true }
+    });
+  });
+
+  test("does NOT dispatch SET_IS_DEFAULT_PAYMENT_METHOD on mount when the flag is absent", () => {
+    const { dispatch } = renderWithStore({ isDefault: false });
+
+    const wasCalledWithSetIsDefault = dispatch.mock.calls.some(
+      ([action]) => action.type === SET_IS_DEFAULT_PAYMENT_METHOD
+    );
+    expect(wasCalledWithSetIsDefault).toBe(false);
+  });
+
+  test("toggling the checkbox dispatches HANDLE_CHECKBOX_CHANGE with the new value", () => {
+    const { dispatch } = renderWithStore({ isDefault: false });
+    const checkbox = screen.getByLabelText("Set as default");
+
+    fireEvent.click(checkbox);
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: HANDLE_CHECKBOX_CHANGE,
+      payload: { isDefault: true }
+    });
+  });
+});


### PR DESCRIPTION
 ---

  ## Summary

  Adds an opt-in "Set as default" checkbox to the payment method create flow in `react-pelcro-js`. Salem Web Network
  tenants (Crosswalk, Bible Study Tools, Christianity, iBelieve) reported that users could not delete old default cards
  after adding a new one because new cards did not auto-default and the backend correctly blocks deletion of an in-use
  default.

  ## Linked tickets

  - ZenDesk: #207455
  - Parent task: [207455] Salem: Improve error handling when Braintree SDK fails to load
  - Asana: <asana-task-url>

  ## Context

  Salem Web Network (Crosswalk, Bible Study Tools, Christianity, iBelieve) reported users cannot delete old default cards
  after adding a new one. Root cause: new cards do not auto-default, and the backend (correctly) blocks deletion of an
  in-use default. Fix is to surface a "Set as default" checkbox on the create flow — opt-in via uiSettings, pre-checked
  when the tenant opts in.

  ## Changes

  - New: `src/Components/PaymentMethodCreate/PaymentMethodCreateSetDefault.js` — mirrors
  `PaymentMethodUpdateSetDefault.js`, no `paymentMethodToEdit` dependency, reads initial state from
  `window.Pelcro.uiSettings.defaultCheckedSetAsDefaultOnCreate`.
  - Modified: `src/Components/PaymentMethod/PaymentMethodView.js` (lines 187–192 area) — extends the existing update-path
  render to also render the new component on create when `window.Pelcro.uiSettings.showSetAsDefaultOnCreate === true`.
  - Modified: `src/Components/PaymentMethod/PaymentMethodContainer.js` — adds `is_default: state.isDefault` to three
  create payloads: Braintree (`createNewBraintreeCard`), Stripe (`createPaymentSource`), Vantiv (`createNewVantivCard`).
  - New tests: `src/Components/PaymentMethodCreate/__tests__/PaymentMethodCreateSetDefault.test.js` — 6 tests covering
  render gating, default checked state, dispatch behaviour.

  ## Cross-tenant safety

  Both `window.Pelcro.uiSettings.showSetAsDefaultOnCreate` and
  `window.Pelcro.uiSettings.defaultCheckedSetAsDefaultOnCreate` default to `false`. Tenants that do not set them see zero
  change in UI or behaviour. Verified by reading the gate condition.

  ## Out of scope (do not block on this PR)

  - `pelcro-client-sdk` — currently strips `is_default` from the create POST allow-list at
  `src/models/payment_methods.js:45-48`. Until that patch lands, this PR is end-to-end inert: the widget will send
  `is_default` but the SDK will drop it before the backend sees it. Tracked in a separate task.
  - `pelcro-ui-salem-web-network` — the Salem repo will flip the uiSettings flags in `public/index.html` after the SDK +
  this widget version are both published.
  - `pelcro-core` — already supports `is_default` on create (`PaymentMethodController@store:65` calls `setDefault()`). No
  backend change needed.
  - Cybersource and Tap create paths — those go through `window.Pelcro.source.create` and the backend already defaults all
   new sources. The checkbox is intentionally a no-op for those gateways. Salem uses Braintree.

  ## Tests

  - 61 passed / 61 total (55 pre-existing + 6 new).
  - Lint: 0 errors. 2 new `valid-jsdoc` warnings match the existing sibling component style.

  ## QA — Salem brands (Braintree)

  - Christianity: https://beta.christianity.com/
  - Crosswalk: https://core.crosswalk.com/
  - Bible Study Tools: staging URL TBD (client to provide)
  
  Test matrix per brand:
  
  - Add card with checkbox checked — new card becomes default — old card can be deleted.
  - Add card with checkbox unchecked — new card saved, previous default unchanged.
  - Smoke-test a non-Salem tenant (any publisher without the flag) — checkbox does NOT appear, no behaviour change.

  ## Rollback
  
  The change is gated behind two uiSettings flags. To roll back, set `showSetAsDefaultOnCreate = false` in the consuming
  tenant's `index.html` — no widget revert needed. The SDK and backend changes are independently revertable in their own
  PRs.
  
  ## Deployment order (post-merge)

  1. Cut a `react-pelcro-js` release (semantic-release will publish from master).
  2. Land the pelcro-client-sdk PR + publish.
  3. Bump both dependencies in `pelcro-ui-salem-web-network/package.json`.
  4. Flip Salem's `uiSettings` flags in `public/index.html`.
  5. Deploy Salem to staging — QA across 4 brands — deploy to prod.
  
  ## SOC2 / change record
  
  Payment-touching change. Change record to be opened by PS team before production deploy, linking ZenDesk #207455 and
  this PR.

  ---

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213968729203165